### PR TITLE
Add benchmarks for simple subquery

### DIFF
--- a/py/specs/select/simple_subquery.toml
+++ b/py/specs/select/simple_subquery.toml
@@ -1,0 +1,26 @@
+[setup]
+statement_files = ["../sql/uservisits.sql"]
+statements = [
+    "copy uservisits from 's3://crate.amplab/data/1node/uservisits/part-00001*' with (compression = 'gzip')",
+    "copy uservisits from 's3://crate.amplab/data/1node/uservisits/part-00002*' with (compression = 'gzip')",
+    "copy uservisits from 's3://crate.amplab/data/1node/uservisits/part-00003*' with (compression = 'gzip')",
+    "copy uservisits from 's3://crate.amplab/data/1node/uservisits/part-00004*' with (compression = 'gzip')",
+    "copy uservisits from 's3://crate.amplab/data/1node/uservisits/part-00005*' with (compression = 'gzip')",
+    "refresh table uservisits"
+]
+
+
+[[queries]]
+statement = '''select * from (select * from uservisits order by "adRevenue" asc limit 500) t order by "adRevenue" desc limit 100
+'''
+iterations = 2000
+
+
+[[queries]]
+statement = '''select * from (select * from uservisits order by "adRevenue" asc limit 200000) t order by "adRevenue" desc limit 100
+'''
+iterations = 50
+
+
+[teardown]
+statements = ["drop table uservisits"]


### PR DESCRIPTION
This requires functionality that is in the `simple-subquery` branch in the
crate project, so don't merge yet.


First query:

```
Runtime (in ms):
    mean:    24.132 ± 0.181
    min/max: 9.362 → 70.624
Percentile:
    50:   24.887 ± 4.129 (stdev)
    95:   27.873
    99.9: 63.995
```

Second query: (this should get a lot faster once we add the fetch-propagation optimization)

```
Runtime (in ms):
    mean:    1287.632 ± 25.463
    min/max: 1137.688 → 1486.777
Percentile:
    50:   1290.236 ± 91.861 (stdev)
    95:   1434.237
    99.9: 1486.777
```