### PR TITLE
Change slow join query into one that is a lot faster

### DIFF
--- a/py/specs/joins.toml
+++ b/py/specs/joins.toml
@@ -12,7 +12,7 @@ iterations = 50
 
 [[queries]]
 # QAF
-statement = "select articles.name as article, colors.name as color from articles, colors order by article, color limit 10000"
+statement = "select articles.name as article from articles, colors order by article limit 10000"
 iterations = 2560
 
 [[queries]]


### PR DESCRIPTION
The query was really slow (> 1800sec) because the pre-join ORDER BY
optimization can't be applied and sorting 100k*100k rows is slow.