### PR TITLE
adds benchmarks for disabled doc_values/column store

### DIFF
--- a/py/specs/select/disabled_doc_values.toml
+++ b/py/specs/select/disabled_doc_values.toml
@@ -1,0 +1,25 @@
+[setup]
+statement_files = ["sql/uservisits_no_doc_values.sql"]
+statements = [
+    "copy uservisits_no_doc_values from 's3://crate.amplab/data/1node/uservisits/part-00001*' with (compression = 'gzip')",
+    "copy uservisits_no_doc_values from 's3://crate.amplab/data/1node/uservisits/part-00002*' with (compression = 'gzip')",
+    "copy uservisits_no_doc_values from 's3://crate.amplab/data/1node/uservisits/part-00003*' with (compression = 'gzip')",
+    "copy uservisits_no_doc_values from 's3://crate.amplab/data/1node/uservisits/part-00004*' with (compression = 'gzip')",
+    "copy uservisits_no_doc_values from 's3://crate.amplab/data/1node/uservisits/part-00005*' with (compression = 'gzip')",
+    "refresh table uservisits_no_doc_values"
+]
+
+[[queries]]
+statement = '''select avg("adRevenue") from uservisits_no_doc_values'''
+iterations = 500
+
+[[queries]]
+statement = '''select "cCode", count(*) from uservisits_no_doc_values group by "cCode"'''
+iterations = 100
+
+[[queries]]
+statement = '''select * from uservisits_no_doc_values order by "adRevenue" limit 10'''
+iterations = 1000
+
+[teardown]
+statements = ["drop table uservisits_no_doc_values"]

--- a/py/specs/sql/uservisits_no_doc_values.sql
+++ b/py/specs/sql/uservisits_no_doc_values.sql
@@ -1,0 +1,16 @@
+CREATE TABLE uservisits_no_doc_values (
+   "sourceIP" STRING PRIMARY KEY,
+   "destinationURL" STRING,
+   "visitDate" TIMESTAMP,
+   "adRevenue" FLOAT STORAGE WITH (columnstore = false),
+   "UserAgent" STRING INDEX USING FULLTEXT,
+   "cCode" STRING STORAGE WITH (columnstore = false),
+   "lCode" STRING,
+   "searchWord" STRING,
+   "duration" INTEGER,
+   INDEX uagent_plain USING PLAIN("UserAgent")
+   -- ^^ used for regex matching ^^ --
+) WITH (
+    number_of_replicas = 0,
+    refresh_interval = 0
+);

--- a/py/tracks/latest.toml
+++ b/py/tracks/latest.toml
@@ -47,5 +47,6 @@ full = [
     "../specs/select/*.toml",
     "../specs/in_subquery.toml",
     "../specs/in_subquery.toml",
-    "../specs/union.toml"
+    "../specs/union.toml",
+    "../specs/select/disabled_doc_values.toml"
 ]


### PR DESCRIPTION
groupings, aggregates and ordering on columns with disabled doc_values
uses a source lookup. this benchmarks are intended to be compared to the
equivalent benchmarks with enabled doc_values to see the performance
differences