### PR TITLE
Stabilize join benchmark by running optimize table

### DIFF
--- a/py/specs/joins.toml
+++ b/py/specs/joins.toml
@@ -3,7 +3,9 @@ statement_files = ["sql/articles.sql", "sql/colors.sql"]
 statements = [
     "copy articles from 's3://crate-stresstest-data/join-sample-data/articles_*' with (compression = 'gzip')",
     "copy colors from 's3://crate-stresstest-data/join-sample-data/colors_*' with (compression = 'gzip')",
-    "refresh table articles, colors"
+    "refresh table articles, colors",
+    "optimize table colors with (max_num_segments = 1)",
+    "optimize table articles with (max_num_segments = 1)",
 ]
 
 [[queries]]


### PR DESCRIPTION
The benchmark

    select * from articles inner join colors on articles.id = colors.id
    where colors.id = -1

depends a lot on the number of segments because one side doesn't match
at all. Our current NL implementation still retries to iterate over the
right side for each left row and if each segment contains no matching
row the cost of setting up the doc-iteration per segment is
proportionally high.

We should optimize this eventually in CrateDB, but this here is to avoid
having the benchmarks fluctuate so much, to reduce false positive
regression notifications.