### PR TITLE
stabilized performance regression in nightly benchmarks

### DIFF
--- a/py/specs/in_subquery.toml
+++ b/py/specs/in_subquery.toml
@@ -8,11 +8,11 @@ statements = [
 
 [[queries]]
 statement = "select * from articles where id in (select id from colors where coolness > 0) limit 10000"
-iterations = 100
+iterations = 200
 
 [[queries]]
 statement = "select * from articles where id not in (select id from colors where coolness > 0) limit 10000"
-iterations = 100
+iterations = 200
 
 [teardown]
 statements = ["drop table articles", "drop table colors"]

--- a/py/specs/joins.toml
+++ b/py/specs/joins.toml
@@ -10,7 +10,7 @@ statements = [
 
 [[queries]]
 statement = "select * from articles inner join colors on articles.id = colors.id order by articles.id limit 1000"
-iterations = 50
+iterations = 200
 
 [[queries]]
 # QAF
@@ -20,12 +20,12 @@ iterations = 2560
 [[queries]]
 # QTF
 statement = "select * from articles CROSS JOIN colors limit 1 offset 10000"
-iterations = 50
+iterations = 200
 
 [[queries]]
 # colors.id = -1 -> no match -> join condition can't match
 statement = "select * from articles inner join colors on articles.id = colors.id where colors.id = -1"
-iterations = 50
+iterations = 150
 
 
 [teardown]


### PR DESCRIPTION
Increased the error quotient from 10% to 15% due to high query runtime
fluctuations on a lot of queries on the benchmark servers.

Additionally it is necessary to define certain queries as "unstable"
since their error quotient is most of the time higher than 15%.