### PR TITLE
Change find_regressions to look at more data and use a breakout approach

### DIFF
--- a/py/find_regressions.py
+++ b/py/find_regressions.py
@@ -2,15 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-Script to find performance regressions by looking at benchmark runs from the
-last 2 days
-
-In order to determine if there is a significant performance difference a t-test
-is done.
-(https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_ind.html#scipy.stats.ttest_ind)
-
-This is not a bullet proof approach, it is used because of a lack of (known)
-better alternatives.
+Script that tries to detect performance regression by looking at previous
+benchmark results
 """
 
 import argparse
@@ -21,7 +14,6 @@ from termcolor import colored
 from itertools import groupby
 from datetime import datetime, timedelta
 from crate.client import connect
-from scipy import stats
 
 
 class Key(NamedTuple):
@@ -35,8 +27,8 @@ class Diff(NamedTuple):
     key: Key
     prev_version: str
     new_version: str
-    prev_p50: float
-    new_p50: float
+    prev_val: float
+    new_val: float
     diff: float
 
 
@@ -48,65 +40,22 @@ class Row(NamedTuple):
     meta_name: str
     ended: int
     samples: int
+    minimum: int
     percentile50: float
 
 
 UNSTABLE_PREDICATES = [
     # fluctuates between 8 and 18 ms
-    lambda d: (d.key.stmt.startswith('insert into articles') and d.diff < 200),
+    lambda d: (d.key.stmt.startswith('insert into articles') and d.diff < 100),
 
     # fluctuates between 7 and 14 ms
     lambda d: (d.key.stmt.startswith('insert into id_int_value_str') and d.diff < 100),
-
-    # fluctuates up to 35% if chart history is taken into account
-    lambda d: (
-        d.key.stmt == 'select extract(day from "visitDate"), count(*) from uservisits group by 1 order by 2 desc limit 20' and
-        d.diff < 35),
-
-    # fluctuates up to 100%
-    # declared unstable by taking chart history and mean runtimes of only 0.5 - 1.0 ms into account
-    lambda d: (d.key.stmt.startswith('select _uid from t') and d.diff < 100),
-
-    # fluctuates up to 30%
-    # declared unstable by taking chart history and low mean runtime (0.5 - 5 ms) into account
-    lambda d: (
-        d.key.stmt.startswith('select * from uservisits limit') and
-        d.key.concurrency == 1 and
-        d.diff < 30),
-
-    # fluctuates up to 40%
-    # declared unstable by taking chart history into account
-    lambda d: (
-        d.key.stmt.startswith('select * from uservisits order by "adRevenue"') and
-        d.diff < 40),
-
-    # fluctuates up to 40%
-    # declared unstable by taking chart history and mean runtimes of only 0.5 - 1.5 ms into account
-    lambda d: (d.key.stmt.startswith('select count(*) from uservisits') and d.diff < 40),
-
-    # fluctuates up to 50%
-    # declared unstable by taking chart history and low mean runtime (1.5 - 2.5 ms) into account
-    lambda d: (
-        d.key.stmt.startswith('select * from articles CROSS JOIN colors limit 1 offset 10000') and
-        d.diff < 50),
-
-    # fluctuates up to 30%
-    # declared unstable by taking chart history into account
-    # unstable for     != any(?)    = any(?)
-    lambda d: (d.key.stmt.startswith('select * from t_any where value') and d.diff < 30),
-
-    # fluctuates up to 50%
-    # declared unstable by taking chart history into account
-    # TODO: find out why NOT IN () fluctuates much stronger than IN ()
-    lambda d: (
-        d.key.stmt.startswith('select * from articles where id not in (select id from colors where coolness > 0)') and
-        d.diff < 50),
 ]
 
 
 def _fetch_results(c):
-    two_days_ago = (datetime.today() - timedelta(days=2))
-    two_days_ago = int(two_days_ago.timestamp() * 1000)
+    twenty_days_ago = (datetime.today() - timedelta(days=20))
+    twenty_days_ago = int(twenty_days_ago.timestamp() * 1000)
     c.execute('''
 select
     statement,
@@ -116,6 +65,7 @@ select
     meta['name'] as meta_name,
     ended,
     runtime_stats['samples'],
+    runtime_stats['min'] as minimum,
     runtime_stats['percentile']['50'] as p50
 from
     benchmarks
@@ -129,13 +79,8 @@ order by
     version_info['number'],
     version_info['hash'],
     ended desc
-''', (two_days_ago,))
+''', (twenty_days_ago,))
     return (Row(*r) for r in c.fetchall())
-
-
-# critical value for a confidence level of 99% - assuming a normal distribution
-# See also: http://stattrek.com/statistics/dictionary.aspx?definition=critical_value
-critical_value = stats.norm.ppf([0.99])[0]
 
 
 def find_diffs(results):
@@ -145,43 +90,33 @@ def find_diffs(results):
         list of diffs
 
     >>> find_diffs([
-    ...     Row('select name', '0.56.0', 1, 1, 'dummy.toml', 12345789000, [11, 12, 20], 11),
-    ...     Row('select name', '0.57.0', 1, 1, 'dummy.toml', 12345789000, [10, 10, 20], 10),
-    ...     Row('select name', '0.58.0', 1, 1, 'dummy.toml', 12345789000, [25, 25, 35], 25),
+    ...     Row('select name', '0.56.0', 1, 1, 'dummy.toml', 12345789000, [11, 12, 20], 10, 11),
+    ...     Row('select name', '0.57.0', 1, 1, 'dummy.toml', 12345789000, [10, 10, 20], 10, 10),
+    ...     Row('select name', '0.58.0', 1, 1, 'dummy.toml', 12345789000, [25, 25, 35], 25, 25),
     ... ])
-    [Diff(key=Key(concurrency=1, stmt='select name', bulk_size=1, meta_name='dummy.toml'), prev_version='0.57.0', new_version='0.58.0', prev_p50=10, new_p50=25, diff=150.0)]
+    [Diff(key=Key(concurrency=1, stmt='select name', bulk_size=1, meta_name='dummy.toml'), prev_version='0.56.0', new_version='0.58.0', prev_val=10, new_val=25, diff=150.0)]
     """
     diffs = []
     for stmt_c, group in groupby(
             results,
             lambda r: (r.stmt, r.concurrency, r.bulk_size, r.meta_name)):
-        prev = None
-        for g in group:
-            if not prev or prev.version == g.version:
-                prev = g
-                continue
-            try:
-                ind = stats.ttest_ind(prev.samples, g.samples)
-            except TypeError:
-                prev = g
-                continue
-            tscore = ind.statistic
-            prev_p50 = prev.percentile50
-            new_p50 = g.percentile50
-            if new_p50 < prev_p50 or math.isclose(new_p50, prev_p50, abs_tol=0.001):
-                prev = g
-                continue
-            diff = (new_p50 - prev_p50) * 100 / prev_p50
-            if abs(tscore) >= critical_value:
-                diffs.append(Diff(
-                    Key(g.concurrency, g.stmt.strip(), g.bulk_size, g.meta_name),
-                    prev.version,
-                    g.version,
-                    prev_p50,
-                    new_p50,
-                    diff
-                ))
-            prev = g
+        group = list(group)
+        if len(group) < 3:
+            continue
+        largest_min = max((r.minimum for r in group[:-1]))
+        worst_result = next((r for r in group if r.minimum == largest_min))
+        last_row = list(group)[-1]
+        if last_row.minimum < largest_min or math.isclose(last_row.minimum, largest_min, abs_tol=0.001):
+            continue
+        diff = (last_row.minimum - largest_min) * 100 / largest_min
+        diffs.append(Diff(
+            Key(last_row.concurrency, last_row.stmt.strip(), last_row.bulk_size, last_row.meta_name),
+            worst_result.version,
+            last_row.version,
+            largest_min,
+            last_row.minimum,
+            diff
+        ))
     return diffs
 
 
@@ -197,14 +132,14 @@ def print_diffs(diffs):
         for g in group:
             values = g._asdict()
             diff_fmt = '{0:5.1f}'
-            if g.diff > 15:
+            if g.diff > 10:
                 diff_fmt = colored(diff_fmt, 'red', attrs=['bold'])
-            elif g.diff > 10:
+            elif g.diff > 5:
                 diff_fmt = colored(diff_fmt, 'red')
             values['diff'] = diff_fmt.format(g.diff)
 
             print(('  {prev_version} → {new_version}\n'
-                   '  {diff}%   {prev_p50:.3f} → {new_p50:.3f}').format(**values))
+                   '  {diff}%   {prev_val:.3f} → {new_val:.3f}').format(**values))
             print('')
 
 


### PR DESCRIPTION
Given the large fluctuation of the benchmarks comparing only the last
two results results in a large number of false positive alerts.
Furthermore it has the "boiling frog" problem in that we don't detect
slow regressions over time if we constantly ignore 10%+ differences.

This changes the approach: Now it looks at the last 20 results in
compares the latest with the *worst* of the previous 19 results. This should reduce the change of false positive alerts and at the same time improve the chance of detecting slow regressions.