### PR TITLE
Remove `indices.store.throttle.max_bytes_per_sec`

### DIFF
--- a/py/tracks/default.toml
+++ b/py/tracks/default.toml
@@ -6,6 +6,5 @@
 "cluster.name" = "cr8"
 "node.name" = "bench1"
 "stats.enabled" = true
-"indices.store.throttle.max_bytes_per_sec" = "100mb"
 "logger._root" = "ERROR"
 "logger.http" = "INFO"


### PR DESCRIPTION
Has been removed in CrateDB 3.0