### PR TITLE
Set `path.logs` and `path.data` for query_tests track

### DIFF
--- a/query_tests/2g.toml
+++ b/query_tests/2g.toml
@@ -1,2 +1,7 @@
 [env]
 "CRATE_HEAP_SIZE" = "2g"
+
+[settings]
+"path.logs" = "./crate-logs/"
+"path.data" = "./crate-data/"
+"discovery.type" = "single-node"


### PR DESCRIPTION
- To have the logs in the jenkins workspace
 - To have the data in the jenkins workspace. Otherwise the default is
 `/tmp/` which is backed by `tmpfs` and therefore limited by space.