### PR TITLE
rnd_queries: Use unix_time for timestamp value generation

### DIFF
--- a/query_tests/generate_rnd_queries.py
+++ b/query_tests/generate_rnd_queries.py
@@ -124,6 +124,7 @@ def abs(data_faker, column, provider):
     compare_to = provider()
     return f"({column}>0 AND abs(({column}-{column}) + ({column}/{column})) != {compare_to})"
 
+
 def ceil(data_faker, column, provider):
     compare_to = data_faker.provider_for_column("byte", "byte")()
     return f"({column}!=0 AND CEIL({column}/{column}) != {compare_to})"
@@ -407,7 +408,11 @@ def rnd_expr(data_faker, columns):
         column = random.choice(list(columns.keys()))
         data_type = columns[column]
         inner_type, *dimensions = data_type.split('_array')
-    provider = data_faker.provider_for_column(column, inner_type)
+    if inner_type == 'timestamp':
+        def provider():
+            return data_faker.fake.unix_time() * 1000
+    else:
+        provider = data_faker.provider_for_column(column, inner_type)
     if inner_type in TYPE_REQUIRES_QUOTES:
         provider = partial(add_quotes, provider)
     use_scalar = every(15)


### PR DESCRIPTION
The change in cr8 https://github.com/mfussenegger/cr8/commit/3ef2040dd49eeeee4937f2e35d368e1e15651313 broke the value generation for timestamps, leading to queries like this:

    SELECT count(*) FROM \"benchmarks\".\"query_tests\" WHERE 2016-08-20
    23:16:44 >= ANY (\"atimestamp\") AND \"slong\" <= -3771834702135012260
    AND \"stimestamp\" != 2017-02-19 23:43:01;