### PR TITLE
Change GROUP BY queries to run with concurrency

### DIFF
--- a/specs/group_by.toml
+++ b/specs/group_by.toml
@@ -11,26 +11,22 @@ statements = [
 
 [[queries]]
 statement = '''select "cCode", count(*) from uservisits group by "cCode"'''
+concurrency = 15
 iterations = 100
 
 [[queries]]
 statement = '''select min("adRevenue") from uservisits group by "cCode"'''
-iterations = 100
-
-[[queries]]
-statement = '''select max("adRevenue") from uservisits group by "cCode"'''
+concurrency = 15
 iterations = 100
 
 [[queries]]
 statement = '''select avg("adRevenue") from uservisits group by "cCode"'''
+concurrency = 15
 iterations = 100
 
 [[queries]]
 statement = '''select count(distinct "searchWord") from uservisits group by "cCode"'''
-iterations = 100
-
-[[queries]]
-statement = '''select arbitrary("searchWord") from uservisits group by "cCode"'''
+concurrency = 5
 iterations = 100
 
 [teardown]


### PR DESCRIPTION
Running them sequentially is not ideal:

 - It's more artificial: Having an idle node where a single query is
 run sequentially is rather unrealistic

 - Since there is lower GC pressure the chance to observe a full GC is
 lower, this can lead to flaky results. Some runs with a full GC happening
 during the measurement and some without.

This also removes `max` and `arbitrary` aggregations. We're not so much
interested in the performance of different aggregation functions, but
rather in the behaviour of the whole pipeline.

We could do targeted JMH benchmarks to compare aggregation functions.