### PR TITLE
Update cr8 to 0.13.0

### DIFF
--- a/compare.py
+++ b/compare.py
@@ -77,7 +77,13 @@ def _run_spec(version, spec, result_hosts, env, settings):
     with Logger() as log, CrateNode(crate_dir=crate_dir, settings=settings, env=env) as n:
         n.start()
         log.result = results.append
-        do_run_spec(spec, n.http_url, log, result_hosts, None)
+        do_run_spec(
+            spec=spec,
+            benchmark_hosts=n.http_url,
+            log=log,
+            result_hosts=result_hosts,
+            sample_mode='reservoir'
+        )
     return results
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-aiohttp==2.3.10
+aiohttp==3.3.2
 argh==0.26.2
-async-timeout==2.0.1
+async-timeout==3.0.0
+attrs==18.1.0
 backcall==0.1.0
 bleach==2.1.3
 chardet==3.0.4
-cr8==0.11.1
+cr8==0.13.0
 crate==0.21.3
 cycler==0.10.0
 decorator==4.3.0


### PR DESCRIPTION
So spec files using gzipped files can be used with ./compare.py