### PR TITLE
Change one group by query case to use multiple columns

### DIFF
--- a/specs/group_by.toml
+++ b/specs/group_by.toml
@@ -20,7 +20,7 @@ concurrency = 15
 iterations = 100
 
 [[queries]]
-statement = '''select avg("adRevenue") from uservisits group by "cCode"'''
+statement = '''select avg("adRevenue") from uservisits group by "cCode", "lCode"'''
 concurrency = 15
 iterations = 100
 


### PR DESCRIPTION
We've multiple ones with `group by cCode` using different aggregation
functions. To compare aggregation function performance we'd be better of
with JMH based benchmarks. Having multiple groupings in one query allows
us to see the behavior of slightly different execution paths in the
engine.