### PR TITLE
Fix benchmark for generated_columns

### DIFF
--- a/specs/sql/generated_columns.sql
+++ b/specs/sql/generated_columns.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS generated_columns (
   id INTEGER,
+  col_0 INTEGER,
   col_1 INTEGER,
   col_2 INTEGER,
   col_3 INTEGER,


### PR DESCRIPTION
Broke due to a missing column and new `static` column_policy default.