### PR TITLE
Allow passing env options containing `=` to compare_run

### DIFF
--- a/compare_run.py
+++ b/compare_run.py
@@ -71,7 +71,7 @@ def run_compare(v1,
 
 def _dict_from_kw_args(args):
     if args:
-        return dict(i.split('=') for i in args)
+        return dict(i.split('=', maxsplit=1) for i in args)
     else:
         return {}
 


### PR DESCRIPTION
Using options like `--env-v2 CRATE_JAVA_OPTS="-XX:InitiatingHeapOccupancyPercent=75"`
didn't work.