### PR TITLE
Raise the query circuit breaker limit

### DIFF
--- a/tracks/default.toml
+++ b/tracks/default.toml
@@ -3,6 +3,7 @@
 
 [settings]
 "bootstrap.memory_lock" = true
+"indices.breaker.query.limit" = "80%"
 "cluster.name" = "cr8"
 "node.name" = "bench1"
 "stats.enabled" = true


### PR DESCRIPTION
This raises it from 60% to 80%, due to the recent accounting
improvements made in CrateDB, some of the queries started hitting the
threshold of 60%.

We know that the queries should work as we were able to successfully run
them before the circuit breaker improvements, so raising the limit
should be safe for the benchmarks.