### PR TITLE
Add metrics extracted from JFR to compare_run

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ charset = utf-8
 [*.py]
 indent_style = space
 indent_size = 4
+
+[*.java]
+indent_style = space
+indent_size = 4

--- a/JfrOverview.java
+++ b/JfrOverview.java
@@ -1,0 +1,329 @@
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.StringJoiner;
+
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedMethod;
+import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordingFile;
+
+
+public class JfrOverview {
+
+    private static double totalAllocated;
+    private static long firstAllocationTime = -1;
+
+    static class DoubleMeasure {
+        
+        private int count = 0;
+        private double total;
+        private double max;
+        private double value;
+
+        public double getAverage() {
+            return total / count;
+        }
+
+		public void add(double value) {
+            this.count++;
+            this.total += value;
+            this.max = Math.max(this.value, value);
+            this.value = value;
+		}
+
+        @Override
+        public String toString() {
+            return "DoubleMeasure{count=" + count + ", max=" + max + ", total=" + total + ", value=" + value + "}";
+        }
+    }
+
+    static class LongMeasure {
+        
+        private int count = 0;
+        private long total;
+        private long max;
+        private long value;
+
+        public LongMeasure() {
+            this.count = 0;
+            this.total = 0;
+            this.max = 0;
+            this.value = 0;
+        }
+
+        public LongMeasure(long value) {
+            this.count = 1;
+            this.total += value;
+            this.max = value;
+            this.value = value;
+        }
+
+        public double getAverage() {
+            if (count == 0) {
+                return total;
+            }
+            return total / count;
+        }
+
+		public void add(long value) {
+            this.count++;
+            this.total += value;
+            this.max = Math.max(this.value, value);
+            this.value = value;
+		}
+    }
+    
+
+    private static List<String> decodeDescriptors(String descriptor) {
+        List<String> descriptors = new ArrayList<>();
+        for (int index = 0; index < descriptor.length(); index++) {
+            String arrayBrackets = "";
+            while (descriptor.charAt(index) == '[') {
+                arrayBrackets += "[]";
+                index++;
+            }
+            char c = descriptor.charAt(index);
+            String type;
+            switch (c) {
+            case 'L':
+                int endIndex = descriptor.indexOf(';', index);
+                type = descriptor.substring(index + 1, endIndex);
+                index = endIndex;
+                break;
+            case 'I':
+                type = "int";
+                break;
+            case 'J':
+                type = "long";
+                break;
+            case 'Z':
+                type = "boolean";
+                break;
+            case 'D':
+                type = "double";
+                break;
+            case 'F':
+                type = "float";
+                break;
+            case 'S':
+                type = "short";
+                break;
+            case 'C':
+                type = "char";
+                break;
+            case 'B':
+                type = "byte";
+                break;
+            default:
+                type = "<unknown-descriptor-type>";
+            }
+            descriptors.add(type + arrayBrackets);
+        }
+        return descriptors;
+    }
+
+    private static String formatMethod(RecordedMethod m) {
+        StringBuilder sb = new StringBuilder();
+        String typeName = m.getType().getName();
+        typeName = typeName.substring(typeName.lastIndexOf('.') + 1);
+        sb.append(typeName).append(".").append(m.getName());
+        sb.append("(");
+        StringJoiner sj = new StringJoiner(", ");
+        String md = m.getDescriptor().replace("/", ".");
+        String parameter = md.substring(1, md.lastIndexOf(")"));
+        for (String qualifiedName : decodeDescriptors(parameter)) {
+            sj.add(qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1));
+        }
+        sb.append(sj.length() > 10 ? "..." : sj);
+        sb.append(")");
+        return sb.toString();
+    }
+
+    private static String topFrame(RecordedStackTrace stackTrace) {
+        if (stackTrace == null) {
+            return null;
+        }
+        List<RecordedFrame> frames = stackTrace.getFrames();
+        if (!frames.isEmpty()) {
+            RecordedFrame topFrame = frames.get(0);
+            if (topFrame.isJavaFrame()) {
+                return formatMethod(topFrame.getMethod());
+            }
+        }
+        return null;
+    }
+
+    public static record Record(String name, int count, long value, long total) {
+    }
+
+    static class Histogram {
+
+        private static final HashMap<String, LongMeasure> histogram = new HashMap<>();
+
+		public void add(String key, long value) {
+            var measure = histogram.get(key);
+            if (measure == null) {
+                measure = new LongMeasure();
+                histogram.put(key, measure);
+            }
+            measure.add(value);
+		}
+
+        public List<Record> getRecords() {
+            ArrayList<Record> values = new ArrayList<>();
+            for (var e : histogram.entrySet()) {
+                var measure = e.getValue();
+                values.add(new Record(e.getKey(), measure.count, measure.value, measure.total));
+            }
+            return values;
+        }
+
+        public Iterable<Record> byTotal() {
+            return () -> getRecords()
+                .stream()
+                .sorted(Comparator.comparingLong(Record::total).reversed())
+                .limit(5)
+                .iterator();
+        }
+
+        public Iterable<Record> byCount() {
+            return () -> getRecords()
+                .stream()
+                .sorted(Comparator.comparingLong(Record::count).reversed())
+                .limit(5)
+                .iterator();
+        }
+    }
+
+    private static final LongMeasure ALLOC_TOTAL = new LongMeasure();
+    private static final DoubleMeasure ALLOC_RATE = new DoubleMeasure();
+    private static final Histogram ALLOCATION_TOP_FRAME = new Histogram();
+
+    private static void onAllocationSample(RecordedEvent event, long size) {
+        String topFrame = topFrame(event.getStackTrace());
+        if (topFrame != null) {
+            ALLOCATION_TOP_FRAME.add(topFrame, size);
+        }
+        ALLOC_TOTAL.add(size);
+        long timestamp = event.getEndTime().toEpochMilli();
+        totalAllocated += size;
+        if (firstAllocationTime > 0) {
+            long elapsedTime = timestamp - firstAllocationTime;
+            if (elapsedTime > 0) {
+                double rate = 1000.0 * (totalAllocated / elapsedTime);
+                ALLOC_RATE.add(rate);
+            }
+        } else {
+            firstAllocationTime = timestamp;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Path to JFR recording required");
+        }
+        var recordingFile = new RecordingFile(Paths.get(args[0]));
+
+        DoubleMeasure machineCpu = new DoubleMeasure();
+        DoubleMeasure jvmSystem = new DoubleMeasure();
+        DoubleMeasure jvmUser = new DoubleMeasure();
+        LongMeasure youngGc = new LongMeasure();
+        LongMeasure oldGc = new LongMeasure();
+        LongMeasure usedHeap = new LongMeasure();
+        LongMeasure physicalMemory = new LongMeasure();
+        DoubleMeasure threads = new DoubleMeasure();
+        LongMeasure classes = new LongMeasure();
+        LongMeasure compilation = new LongMeasure();
+        LongMeasure initialHeap = new LongMeasure();
+        Histogram executionTopFrame = new Histogram();
+        String gcName = "Unknown";
+
+        while (recordingFile.hasMoreEvents()) {
+            var event = recordingFile.readEvent();
+            switch (event.getEventType().getName()) {
+                case "jdk.CPULoad" -> {
+                    machineCpu.add(event.getDouble("machineTotal"));
+                    jvmSystem.add(event.getDouble("jvmSystem"));
+                    jvmUser.add(event.getDouble("jvmUser"));
+                }
+                case "jdk.YoungGarbageCollection" -> {
+                    long nanos = event.getDuration().toNanos();
+                    youngGc.add(nanos);
+                }
+                case "jdk.OldGarbageCollection" -> {
+                    long nanos = event.getDuration().toNanos();
+                    oldGc.add(nanos);
+                }
+                case "jdk.GCHeapSummary" -> {
+                    usedHeap.add(event.getLong("heapUsed"));
+                }
+                case "jdk.PhysicalMemory" -> {
+                    physicalMemory.add(event.getLong("totalSize"));
+                }
+                case "jdk.GCConfiguration" -> {
+                    String gc = event.getString("oldCollector");
+                    String yc = event.getString("youngCollector");
+                    if (yc != null) {
+                        gc += "/" + yc;
+                    }
+                    gcName = gc;
+                }
+                case "jdk.ObjectAllocationOutsideTLAB" -> {
+                    onAllocationSample(event, event.getLong("allocationSize"));
+                }
+                case "jdk.ObjectAllocationInNewTLAB" -> {
+                    onAllocationSample(event, event.getLong("tlabSize"));
+                }
+                case "jdk.ExecutionSample" -> {
+                    String topFrame = topFrame(event.getStackTrace());
+                    executionTopFrame.add(topFrame, 1);
+                }
+                case "jdk.JavaThreadStatistics" -> {
+                    threads.add(event.getDouble("activeCount"));
+                }
+                case "jdk.ClassLoadingStatistics" -> {
+                    long diff = event.getLong("loadedClassCount") - event.getLong("unloadedClassCount");
+                    classes.add(diff);
+                }
+                case "jdk.Compilation" -> {
+                    compilation.add(event.getDuration().toNanos());
+                }
+                case "jdk.GCHeapConfiguration" -> {
+                    initialHeap.add(event.getLong("initialSize"));
+                }
+            }
+        }
+        System.out.println("gc.name:" + gcName);
+        System.out.println("gc.young.count:" + youngGc.count);
+        System.out.println("gc.young.max:" + youngGc.max);
+        System.out.println("gc.young.avg:" + youngGc.getAverage());
+        System.out.println("gc.old.count:" + oldGc.count);
+        System.out.println("gc.old.max:" + oldGc.max);
+        System.out.println("gc.old.avg:" + oldGc.getAverage());
+        System.out.println("sys.cpu:" + machineCpu.getAverage());
+        System.out.println("jvm.sys:" + jvmSystem.getAverage());
+        System.out.println("jvm.user:" + jvmUser.getAverage());
+        System.out.println("heap.used:" + usedHeap.value);
+        System.out.println("heap.initial:" + initialHeap.value);
+        System.out.println("memory:" + physicalMemory.value);
+        System.out.println("threads:" + threads.value);
+        System.out.println("classes:" + classes.value);
+        System.out.println("compilation:" + compilation.total);
+        System.out.println("alloc.rate:" + (long) ALLOC_RATE.value);
+        System.out.println("alloc.total:" + ALLOC_TOTAL.total);
+
+        for (var rec : ALLOCATION_TOP_FRAME.byTotal()) {
+            System.out.println("  " + rec.name() + ":" + rec.total());
+        }
+        System.out.println("---");
+        for (var rec : executionTopFrame.byCount()) {
+            System.out.println("  " + rec.name() + ":" + rec.count());
+        }
+    }
+}

--- a/compare_measures.py
+++ b/compare_measures.py
@@ -9,6 +9,7 @@ The measures files should contain 1 number per line
 """
 
 import argparse
+import numpy as np
 from scipy import stats
 from cr8 import metrics
 
@@ -26,30 +27,35 @@ class Diff:
     def __init__(self, r1, r2):
         self.r1 = r1
         self.r2 = r2
-        r1_samples = r1.get('samples', [r1['mean']])
-        r2_samples = r2.get('samples', [r2['mean']])
+        r1_samples = np.array(r1.get('samples', [r1['mean']]))
+        r2_samples = np.array(r2.get('samples', [r2['mean']]))
         ind = stats.ttest_ind(r1_samples, r2_samples)
-        tscore = ind.statistic
+        self.r1_ci = stats.norm.interval(0.95, loc=r1_samples.mean(), scale=r1_samples.std(ddof=1))
+        self.r2_ci = stats.norm.interval(0.95, loc=r2_samples.mean(), scale=r2_samples.std(ddof=1))
         self.mean_diff = perc_diff(r1['mean'], r2['mean'])
         self.median_diff = perc_diff(r1['percentile']['50'], r2['percentile']['50'])
-        if abs(tscore) >= CRITICAL_VALUE:
-            self.significance = 'Likely significant'
+        probability = (1 - ind.pvalue) * 100.0
+        self.ptext = f'There is a {probability:.2f}% probability that the observed difference is not random or due to noise, and the best estimate of that difference is {self.mean_diff:.2f}%'
+        if abs(ind.statistic) >= CRITICAL_VALUE:
+            self.significance = 'The test has statistical significance'
         else:
-            self.significance = 'Likely NOT significant'
+            self.significance = 'The test has no statistical significance'
 
     def __str__(self):
         return json.dumps(self.__dict__)
 
 
 def print_diff(diff):
+    mean_prefix = '+' if diff.r1['mean'] < diff.r2['mean'] else '-'
+    median_prefix = '+' if diff.r1['percentile']['50'] < diff.r2['percentile']['50'] else '-'
     print(f'| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |')
     print(f"|   V1    |   {diff.r1['mean']:10.3f} ± {diff.r1['stdev']:8.3f} | {diff.r1['min']:10.3f} | {diff.r1['percentile']['50']:10.3f} | {diff.r1['percentile']['75']:10.3f} | {diff.r1['max']:10.3f} |")
     print(f"|   V2    |   {diff.r2['mean']:10.3f} ± {diff.r2['stdev']:8.3f} | {diff.r2['min']:10.3f} | {diff.r2['percentile']['50']:10.3f} | {diff.r2['percentile']['75']:10.3f} | {diff.r2['max']:10.3f} |")
-
-    mean_prefix = '+' if diff.r1['mean'] < diff.r2['mean'] else '-'
-    median_prefix = '+' if diff.r1['percentile']['50'] < diff.r2['percentile']['50'] else '-'
-    print(f'mean:   {mean_prefix}{diff.mean_diff:7.2f}%')
-    print(f'median: {median_prefix}{diff.median_diff:7.2f}%')
+    print(f'├---------┴-------------------------┴------------┴------------┴------------┴------------┘')
+    print(f"|               {mean_prefix}{diff.mean_diff:7.2f}%                           {median_prefix}{diff.median_diff:7.2f}%   ")
+    print(f'| V1 mean is within {diff.r1_ci[0]:.2f} - {diff.r1_ci[1]:.2f}')
+    print(f'| V2 mean is within {diff.r2_ci[0]:.2f} - {diff.r2_ci[1]:.2f}')
+    print(f'{diff.ptext}')
     print(f'{diff.significance}')
     print('')
 

--- a/compare_measures.py
+++ b/compare_measures.py
@@ -35,7 +35,7 @@ class Diff:
         self.mean_diff = perc_diff(r1['mean'], r2['mean'])
         self.median_diff = perc_diff(r1['percentile']['50'], r2['percentile']['50'])
         probability = (1 - ind.pvalue) * 100.0
-        self.ptext = f'There is a {probability:.2f}% probability that the observed difference is not random or due to noise, and the best estimate of that difference is {self.mean_diff:.2f}%'
+        self.ptext = f'There is a {probability:.2f}% probability that the observed difference is not random, and the best estimate of that difference is {self.mean_diff:.2f}%'
         if abs(ind.statistic) >= CRITICAL_VALUE:
             self.significance = 'The test has statistical significance'
         else:
@@ -53,8 +53,6 @@ def print_diff(diff):
     print(f"|   V2    |   {diff.r2['mean']:10.3f} ± {diff.r2['stdev']:8.3f} | {diff.r2['min']:10.3f} | {diff.r2['percentile']['50']:10.3f} | {diff.r2['percentile']['75']:10.3f} | {diff.r2['max']:10.3f} |")
     print(f'├---------┴-------------------------┴------------┴------------┴------------┴------------┘')
     print(f"|               {mean_prefix}{diff.mean_diff:7.2f}%                           {median_prefix}{diff.median_diff:7.2f}%   ")
-    print(f'| V1 mean is within {diff.r1_ci[0]:.2f} - {diff.r1_ci[1]:.2f}')
-    print(f'| V2 mean is within {diff.r2_ci[0]:.2f} - {diff.r2_ci[1]:.2f}')
     print(f'{diff.ptext}')
     print(f'{diff.significance}')
     print('')


### PR DESCRIPTION
Example output:

    Q: select count(distinct "searchWord") from uservisits group by "cCode"
    C: 5
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      945.619 ±  285.149 |    762.244 |    881.228 |    936.162 |   2187.417 |
    |   V2    |      946.812 ±  160.640 |    722.209 |    916.833 |    958.813 |   1720.607 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               +   0.13%                           +   3.96%
    There is a 2.90% probability that the observed difference is not random, and the best estimate of that difference is 0.13%
    The test has no statistical significance


    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |   36    29.18    61.78 |    0     0.00     0.00 |     8590     2616 |  2666.24     132592
     V2 |   36    27.36    52.15 |    0     0.00     0.00 |     8590     2350 |  2445.92     132461

    V1 top allocation frames
      BytesRef.utf8ToString():63420459696
      StringUTF16.compress(...):29273199552
      Float.valueOf(float):13816682747
      GroupingCollector.evalKeyInputs(List):9566020490
      ArrayList.<init>(int):9066434792
    V2 top allocation frames
      BytesRef.utf8ToString():63354973784
      StringUTF16.compress(...):29735760496
      Float.valueOf(float):13807254735
      GroupingCollector.evalKeyInputs(List):9268620255
      ArrayList.<init>(int):9003726512