### PR TITLE
Extend count benchmarks with aliased table case

### DIFF
--- a/specs/select/count.toml
+++ b/specs/select/count.toml
@@ -19,6 +19,10 @@ statement = "select count(*) from uservisits"
 iterations = 200
 
 [[queries]]
+statement = "select count(*) from uservisits AS u"
+iterations = 200
+
+[[queries]]
 statement = '''select count("cCode") from uservisits'''
 iterations = 50
 


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/10588