### PR TITLE
Change query in `in_numeric` to use count(*)

### DIFF
--- a/specs/any.py
+++ b/specs/any.py
@@ -24,12 +24,12 @@ spec = Spec(
     ),
     queries=[
         {
-            'statement': 'select * from t_any where value = any(?)',
+            'statement': 'select count(*) from t_any where value = any(?)',
             'args': ([str(i) for i in range(500)], ),
             'iterations': 5000,
         },
         {
-            'statement': 'select * from t_any where value != any(?)',
+            'statement': 'select count(*) from t_any where value != any(?)',
             'args': ([str(i) for i in range(500)], ),
             'iterations': 5000,
         },

--- a/specs/in_numeric.toml
+++ b/specs/in_numeric.toml
@@ -10,7 +10,7 @@ statements = [
 ]
 
 [[queries]]
-statement = "select * from uservisits where duration in (?, ?, ?, ?, ?)"
+statement = "select count(*) from uservisits where duration in (?, ?, ?, ?, ?)"
 iterations = 1000
 args = [1, 2, 3, 4, 5]
 


### PR DESCRIPTION
The query became quite slow with 4.0.0 because of the removal of the
implicit HTTP limit. The query returns ~1516033 records which is quite a
lot.

The original purprose of the query was to benchmark the `duration IN`
clause, not the retrieval of large results, so this adjusts the query to
do a `count(*)` which reduces the overhead of the result set processing.