### PR TITLE
add data sets with different distributions and spec for group by

### DIFF
--- a/generators/gen-data.py
+++ b/generators/gen-data.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+"""
+CLI to generate JSON records containing bigints with specified probability distribution
+"""
+
+import argparse
+import json
+import numpy as np
+
+def uniform(n):
+    values = np.random.randint(low=-1e10, high=1e10, size=n)
+    for i in values:
+        print(json.dumps({"x": str(i)}))
+
+def normal(n):
+    values = np.random.normal(loc=0, scale=1e10, size=n).astype(long)
+    for i in values:
+        print(json.dumps({"x": str(i)}))
+
+def poisson(n):
+    # Poisson distribution with a larger value for the mean (loc parameter)
+    # will exhibit a bell shape just like normal distribution. Since normal
+    # distribution is covered by a different data set generating function,
+    # we use a small value for the loc to get a different shape (skewed to the right side).
+
+    #Also, loc should not be 1 in order not to get a shape similar to exponential distribution.
+    values = np.random.poisson(lam=2, size=n)
+    for i in values:
+        print(json.dumps({"x": str(i)}))
+
+def exponential(n):
+    values = np.random.exponential(scale=1e10, size=n).astype(long)
+    for i in values:
+        print(json.dumps({"x": str(i)}))
+
+SUPPORTED_DISTRIBUTIONS = {
+    'uniform': uniform,
+    'normal': normal,
+    'poisson': poisson,
+    'exponential': exponential
+}
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--num', type=int, help='Number of records to generate')
+    parser.add_argument('--distribution', type=str, help='Probability distribution')
+    args = parser.parse_args()
+    try:
+        generator_func = SUPPORTED_DISTRIBUTIONS[args.distribution]
+        generator_func(args.num)
+    except KeyError:
+        print("distribution '" + args.distribution + "' is not supported.")
+
+if __name__ == "__main__":
+    main()

--- a/generators/gen_specific_distribution.sh
+++ b/generators/gen_specific_distribution.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+chmod +x "generators/gen-data.py"
+generators/gen-data.py --num=1000000 --distribution="$1"

--- a/specs/group_by_distribution_long.toml
+++ b/specs/group_by_distribution_long.toml
@@ -1,0 +1,52 @@
+[setup]
+statements = [
+  "create table uniform (x long) clustered into 5 shards",
+  "create table normal (x long) clustered into 5 shards",
+  "create table poisson (x long) clustered into 5 shards",
+  "create table exponential (x long) clustered into 5 shards",
+]
+
+  [[setup.data_cmds]]
+  target = "uniform"
+  cmd = ['generators/gen_specific_distribution.sh', 'uniform']
+
+  [[setup.data_cmds]]
+  target = "normal"
+  cmd = ['generators/gen_specific_distribution.sh', 'normal']
+
+  [[setup.data_cmds]]
+  target = "poisson"
+  cmd = ['generators/gen_specific_distribution.sh', 'poisson']
+
+  [[setup.data_cmds]]
+  target = "exponential"
+  cmd = ['generators/gen_specific_distribution.sh', 'exponential']
+
+
+[[queries]]
+statement = "select count(*) from (select distinct x from uniform) t"
+concurrency = 10
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from (select distinct x from normal) t"
+concurrency = 10
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from (select distinct x from poisson) t"
+concurrency = 10
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from (select distinct x from exponential) t"
+concurrency = 10
+iterations = 200
+
+[teardown]
+statements = [
+  "drop table if exists uniform",
+  "drop table if exists normal",
+  "drop table if exists poisson",
+  "drop table if exists exponential"
+]

--- a/specs/group_by_distribution_string.toml
+++ b/specs/group_by_distribution_string.toml
@@ -1,0 +1,51 @@
+[setup]
+statements = [
+  "create table uniform (x string) clustered into 5 shards",
+  "create table normal (x string) clustered into 5 shards",
+  "create table poisson (x string) clustered into 5 shards",
+  "create table exponential (x string) clustered into 5 shards",
+]
+
+  [[setup.data_cmds]]
+  target = "uniform"
+  cmd = ['generators/gen_specific_distribution.sh', 'uniform']
+
+  [[setup.data_cmds]]
+  target = "normal"
+  cmd = ['generators/gen_specific_distribution.sh', 'normal']
+
+  [[setup.data_cmds]]
+  target = "poisson"
+  cmd = ['generators/gen_specific_distribution.sh', 'poisson']
+
+  [[setup.data_cmds]]
+  target = "exponential"
+  cmd = ['generators/gen_specific_distribution.sh', 'exponential']
+
+[[queries]]
+statement = "select count(*) from (select distinct x from uniform) t"
+concurrency = 10
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from (select distinct x from normal) t"
+concurrency = 10
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from (select distinct x from poisson) t"
+concurrency = 10
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from (select distinct x from exponential) t"
+concurrency = 10
+iterations = 200
+
+[teardown]
+statements = [
+  "drop table if exists uniform",
+  "drop table if exists normal",
+  "drop table if exists poisson",
+  "drop table if exists exponential"
+]


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11413

Added new data sets (1 million records each) with different distributions, generator and a new spec

Some other distributions are similar to exisiting, like binomial being discrete version of normal (could have actually dropped normal and used binomial but went with normal as it's possible to convert it to int )

tried some others - they are in general either bell-shaped like normal or look like exponential, we can add them of course but this is the minimal list of basic "shapes"

Poisson can be approximated to normal but with small loc it's right skewed - included it as well as it's another possible shape.

Plots generated by 
```

#plt.hist(np.random.normal(loc=0, scale=1e10, size=1000000).astype(long), bins=100)
#plt.hist(np.random.randint(low=-1e10, high=1e10, size=1000000), bins=100)
#plt.hist(np.random.poisson(lam=2, size=1000000), bins=13)
#plt.hist(np.random.exponential(scale=1e10, size=1000000).astype(long), bins=100)

plt.show()
```


<details>
  <summary>uniform</summary>
  
 ![uniform](https://user-images.githubusercontent.com/7446940/157266754-4a12a0c5-ccb2-4948-8f96-e279b0be4d7f.png)
  
</details>

<details>
  <summary>poisson right skewed</summary>
  
![Poisson](https://user-images.githubusercontent.com/7446940/157266771-19297ca5-50e9-4341-8e68-9cfd5d5ce415.png)
  
</details>

<details>
  <summary>normal</summary>
  
![normal](https://user-images.githubusercontent.com/7446940/157266785-c7c4c6fe-367b-4f09-98cd-2f12fb3c4ff4.png)
  
</details>


<details>
  <summary> exponential </summary>
  
![exponential](https://user-images.githubusercontent.com/7446940/157266806-8238aa56-08e2-4d1b-b312-94661e284b97.png)

</details>


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
