### PR TITLE
update Poisson distribution to get big numbers

### DIFF
--- a/generators/gen-data.py
+++ b/generators/gen-data.py
@@ -25,7 +25,10 @@ def poisson(n):
     # we use a small value for the loc to get a different shape (skewed to the right side).
 
     #Also, loc should not be 1 in order not to get a shape similar to exponential distribution.
-    values = np.random.poisson(lam=2, size=n)
+
+    # If X1 and X2 are Poisson random variables with means μ1 and μ2 respectively, then X1 + X2 is a Poisson random variable with mean μ1 + μ2.
+    # We shift data by adding variable to itself 1e10 times, new variable X is sum of 1e10 variables and mean is also sum of 1e10 means.
+    values = np.random.poisson(lam=2, size=1000000) * 1e10,
     for i in values:
         print(json.dumps({"x": str(i)}))
 


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11413

I didn't do shift in the prev PR as I misunderstood statement [constant multiplied by a Poisson random variable is not Poisson](https://math.stackexchange.com/questions/746760/prove-that-a-constant-multiplied-by-a-poisson-random-variable-is-not-poisson)

We can use rule [If X1 and X2 are Poisson random variables with means μ1 and μ2 respectively, then X1 + X2 is a Poisson random variable with mean μ1 + μ2.]( https://en.wikipedia.org/wiki/Relationships_among_probability_distributions#Sum_of_variables) - so we just re-use variable X as many times as we need and get an updated variable which is sum of many poisson variables. 

Essentially, we are multiplying the whole formula by `1e10`, ie. multiplying output vector, whereas  multiplication of constant which confused me  is about [multiplying only K in the PMF formula](https://math.stackexchange.com/a/1640155/270352 )


Plot generated by `plt.hist(np.random.poisson(lam=2, size=1000000) * 1e10, bins=13)`
<details>
  <summary>shifted poisson</summary>
  
![figure_1](https://user-images.githubusercontent.com/7446940/157489415-6f233d50-9d6f-4513-b383-3e2f2ac710da.png)
  
</details>


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
