### PR TITLE
increase breaker.query.limit for the public benchmark

### DIFF
--- a/tracks/default.toml
+++ b/tracks/default.toml
@@ -3,7 +3,7 @@
 
 [settings]
 "bootstrap.memory_lock" = true
-"indices.breaker.query.limit" = "80%"
+"indices.breaker.query.limit" = "85%"
 "cluster.name" = "cr8"
 "node.name" = "bench1"
 "stats.enabled" = true


### PR DESCRIPTION
Relates to https://github.com/crate/crate-alerts/issues/225

Problematic query/concurrency combination is
```
statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 
              on t1."sourceIP" = t2."sourceIP" 
              order by t1."sourceIP" limit 1000'
iterations = 20
min_version = '3.0.0'
concurrency = 20
```

I changed `hash_joins` spec locally to contain only one query:
```
[setup]
statement_files = ["../sql/uservisits_large_and_small.sql"]

[[queries]]
statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000'
iterations = 20
min_version = '3.0.0'
concurrency = 20


[teardown]
statements = ["drop table if exists uservisits_small", "drop table if exists uservisits_large"]
```
and run 
` cr8 run-crate ./ -e CRATE_HEAP_SIZE=4g --s indices.breaker.query.limit=80% -- run-spec ../crate-benchmarks/specs/select/hash_joins.toml {node.http_url}`
 
against different revisions, twice per revision (including some old revisions, much earlier before first such failure/HW update) It failed locally with `CurcuitBreakerException` against all revisions :

so I see 2 causes (both related to GC behavior change)

1. different GC behavior related to HW update, public benchmark [started](https://jenkins.crate.io/job/CrateDB/job/nightly/job/crate-public-bench/) to fail from 22.03, HW update was on 20.03. The only [successful manual run](https://jenkins.crate.io/job/CrateDB/job/nightly/job/crate-public-bench/39/) in between could be just occasional success (there a some seldom passes in that benchmark)

2. There was a commit/combination of commits which hardly affected GC  behavior - not sure how to address that - create a script that runs every single commit for the last, say, 2 months and produces 5 jfr files per commit (to handle noise) and then somehow make retro analysis of all together?

In a retrospective, we might want to thoroughly investigate G1GC tuning  (first try different things on public/dev benchmarks and if there is not a single regression, migrate it to our default GC settings/recommendations in docs) - should I create an issue to track it?

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
