### PR TITLE
increase breaker limit for the public benchmark

### DIFF
--- a/tracks/default.toml
+++ b/tracks/default.toml
@@ -3,7 +3,7 @@
 
 [settings]
 "bootstrap.memory_lock" = true
-"indices.breaker.query.limit" = "85%"
+"indices.breaker.query.limit" = "90%"
 "cluster.name" = "cr8"
 "node.name" = "bench1"
 "stats.enabled" = true


### PR DESCRIPTION
resolves https://github.com/crate/crate-alerts/issues/227

public benchmark failed again with 85% - will increase to 90% which passes locally - I hoped that dev machine will behave differently and smaller value would be fine but this is not the case



## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
