### PR TITLE
autogenerate data for huge_arrays on setup

### DIFF
--- a/specs/select/huge_arrays.toml
+++ b/specs/select/huge_arrays.toml
@@ -1,12 +1,10 @@
 [setup]
 statement_files = ["../sql/huge_arrays.sql"]
 
-    [[setup.data_files]]
-    # Data must be generated first using ./generators/huge_arrays.sh > specs/data/huge_arrays.json
+    [[setup.data_cmds]]
     target = "huge_arrays"
-    source = "../data/huge_arrays.json"
+    cmd = ['generators/huge_arrays.sh']
     bulk_size = 500
-
 
 [[queries]]
 statement = "select xs from huge_arrays"


### PR DESCRIPTION
Resolves https://github.com/crate/crate-alerts/issues/228

tested locally, got error without this change and worked with it


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
