### PR TITLE
reduce query circuit breaker back to 80% and set lower concurrency 

### DIFF
--- a/specs/select/hash_joins.toml
+++ b/specs/select/hash_joins.toml
@@ -18,7 +18,7 @@ concurrency = 5
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000'
 iterations = 20
 min_version = '3.0.0'
-concurrency = 20
+concurrency = 17
 
 [[queries]]
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000'
@@ -36,7 +36,7 @@ concurrency = 5
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000'
 iterations = 20
 min_version = '3.0.0'
-concurrency = 20
+concurrency = 17
 
 [[queries]]
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000000'

--- a/tracks/default.toml
+++ b/tracks/default.toml
@@ -3,7 +3,7 @@
 
 [settings]
 "bootstrap.memory_lock" = true
-"indices.breaker.query.limit" = "90%"
+"indices.breaker.query.limit" = "80%"
 "cluster.name" = "cr8"
 "node.name" = "bench1"
 "stats.enabled" = true


### PR DESCRIPTION
Resolves https://github.com/crate/crate-alerts/issues/229

run  
`cr8 run-crate ./ -e CRATE_HEAP_SIZE=4g \
--s indices.breaker.query.limit=80% -- run-spec  ../crate-benchmarks/specs/select/hash_joins.toml {node.http_url}`
 thrice on a local spec with concurrency 17 and it didn't fail 
 
## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
