### PR TITLE
Extend insert benchmarks

### DIFF
--- a/compare_run.py
+++ b/compare_run.py
@@ -133,7 +133,7 @@ def _run_spec(version, spec, result_hosts, env, settings, tmpdir):
             log=log,
             result_hosts=result_hosts,
             sample_mode='reservoir',
-            action='queries'
+            action=['queries', 'load_data']
         )
         jfr_stop(n.process.pid)
         do_run_spec(

--- a/specs/insert_bulk.toml
+++ b/specs/insert_bulk.toml
@@ -1,5 +1,8 @@
 [setup]
 statement_files = ["sql/id_int_value_str.sql"]
+statements = [
+  "create table tbl (id integer, value string) with (number_of_replicas = 0)"
+]
 
 [[load_data]]
 target = "id_int_value_str"
@@ -9,5 +12,29 @@ bulk_size = 1000
 concurrency = 1
 num_records = 1000000
 
+[[load_data]]
+target = "id_int_value_str"
+source = "data/id_int_value_str.json"
+
+bulk_size = 1000
+concurrency = 10
+num_records = 1000000
+
+[[load_data]]
+target = "tbl"
+source = "data/id_int_value_str.json"
+
+bulk_size = 1000
+concurrency = 1
+num_records = 1000000
+
+[[load_data]]
+target = "tbl"
+source = "data/id_int_value_str.json"
+
+bulk_size = 1000
+concurrency = 10
+num_records = 1000000
+
 [teardown]
-statements = ["drop table if exists id_int_value_str"]
+statements = ["drop table if exists id_int_value_str", "drop table if exists tbl"]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Extend insert_bulk benchmarks
- Run `load_data` action in compare_run


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
