### PR TITLE
Add `xs = []` case to array_length benchmark

### DIFF
--- a/specs/array_length.toml
+++ b/specs/array_length.toml
@@ -11,6 +11,14 @@ statements = [
 ]
 
 [[queries]]
+statement = "select count(*) from t_arrays_biased_empty where xs = []"
+iterations = 200
+
+[[queries]]
+statement = "select count(*) from t_arrays_biased_5_elements where xs = []"
+iterations = 200
+
+[[queries]]
 statement = "select count(*) from t_arrays_biased_empty where array_length(xs, 1) > 0"
 iterations = 200
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Used to measure https://github.com/crate/crate/pull/12696

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
