### PR TITLE
Fix `provider_for_column` calls in rnd-query generation

### DIFF
--- a/query_tests/generate_rnd_queries.py
+++ b/query_tests/generate_rnd_queries.py
@@ -126,12 +126,12 @@ def abs(data_faker, column, provider):
 
 
 def ceil(data_faker, column, provider):
-    compare_to = data_faker.provider_for_column("byte", "byte", None)()
+    compare_to = data_faker.provider_for_column(Column("byte", "byte", None))()
     return f"({column}!=0 AND CEIL({column}/{column}) != {compare_to})"
 
 
 def floor(data_faker, column, provider):
-    compare_to = data_faker.provider_for_column("byte", "byte", None)()
+    compare_to = data_faker.provider_for_column(Column("byte", "byte", None))()
     return f"({column}!=0 AND FLOOR({column}/{column}) != {compare_to})"
 
 
@@ -153,7 +153,7 @@ def crate_random(data_faker, column, provider):
 
 
 def round(data_faker, column, provider):
-    compare_to = data_faker.provider_for_column("byte", "byte", None)()
+    compare_to = data_faker.provider_for_column(Column("byte", "byte", None))()
     return f"({column}!=0 AND ROUND({column}/{column}) != {compare_to})"
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Follow up to https://github.com/crate/crate-benchmarks/commit/8a6066d36eafa0b7ad79ad75450fd584e3d3537c

Job failed on Jenkins:

    Traceback (most recent call last):
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/venv/lib/python3.8/site-packages/cr8/run_track.py", line 39, in _run_specs
        do_run_spec(
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/venv/lib/python3.8/site-packages/cr8/run_spec.py", line 257, in do_run_spec
        executor.run_queries(spec.queries, spec.meta)
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/venv/lib/python3.8/site-packages/cr8/run_spec.py", line 180, in run_queries
        for query in queries:
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/query_tests/generate_rnd_queries.py", line 503, in queries_for_spec
        for query in queries:
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/query_tests/generate_rnd_queries.py", line 496, in generate_queries
        yield generate_query(data_faker, columns, schema, table)
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/query_tests/generate_rnd_queries.py", line 468, in generate_query
        for expr in (rnd_expr(data_faker, columns) for _ in expr_range):
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/query_tests/generate_rnd_queries.py", line 468, in <genexpr>
        for expr in (rnd_expr(data_faker, columns) for _ in expr_range):
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/query_tests/generate_rnd_queries.py", line 453, in rnd_expr
        expr = scalar(data_faker, column, provider)
      File "/var/lib/jenkins/workspace/CrateDB/nightly/rnd_query_tests/query_tests/generate_rnd_queries.py", line 129, in ceil
        compare_to = data_faker.provider_for_column("byte", "byte", None)()
    TypeError: provider_for_column() takes 2 positional arguments but 4 were given



## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
