### PR TITLE
Add taplo config to set cr8 spec file schema

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+[[rule]]
+include = ["specs/**/*.toml"]
+
+[rule.schema]
+path = "https://raw.githubusercontent.com/mfussenegger/cr8/master/cr8-spec.schema.json"


### PR DESCRIPTION
If using https://taplo.tamasfe.dev/ this allows to get completion for
spec file properties and schema validation/error reporting

![screenshot](https://user-images.githubusercontent.com/38700/197718385-7ad926a6-a535-4dff-8a80-9e8274b1bd3a.png)

![image](https://user-images.githubusercontent.com/38700/197718459-581a171a-5cd5-4956-b897-d52c27202010.png)

(needs taplo version 0.7.2, there was a bug in 0.7.0 that prevented the config from working)