### PR TITLE
Add whitespace before WHERE clause

### DIFF
--- a/long_running/queries.py
+++ b/long_running/queries.py
@@ -45,7 +45,7 @@ def get_queries():
         },
         {
             'statement': ('SELECT lrt.t1.dev, lrt.t2.name '
-                          'FROM lrt.t1 INNER JOIN lrt.t2 ON lrt.t1.dev = lrt.t2.dev'
+                          'FROM lrt.t1 INNER JOIN lrt.t2 ON lrt.t1.dev = lrt.t2.dev '
                           'WHERE lrt.t1.dev = CAST(random() * 127 AS BYTE) '
                           'ORDER BY lrt.t2.name '
                           'LIMIT 100'),


### PR DESCRIPTION
`SqlException: SQLParseException[line 1:94: mismatched input 'lrt' expecting {<EOF>, ';'}] occurred using: {"stmt": "SELECT lrt.t1.dev, lrt.t2.name FROM lrt.t1 INNER JOIN lrt.t2 ON lrt.t1.dev = lrt.t2.devWHERE lrt.t1.dev = CAST(random() * 127 AS BYTE) ORDER BY lrt.t2.name LIMIT 100"}`

This issue ^ [pops up from time to time](https://github.com/crate/crate-alerts/search?q=%22lrt.t1.dev+%3D+lrt.t2.devWHERE%22&type=issues) and gets automatically closed.
