### PR TITLE
lower concurrency for long-running query as it causes JobKilledException

### DIFF
--- a/long_running/queries.py
+++ b/long_running/queries.py
@@ -49,7 +49,7 @@ def get_queries():
                           'WHERE lrt.t1.dev = CAST(random() * 127 AS BYTE) '
                           'ORDER BY lrt.t2.name '
                           'LIMIT 100'),
-            'concurrency': 25,
+            'concurrency': 20,
             'duration': 1 * 60 * 60
         },
         {


### PR DESCRIPTION
https://jenkins.crate.io/job/CrateDB/job/nightly/job/long_running/

1. one of the queries was never executed, crate-alerts issue used to [pop up and then be autofixed](https://github.com/crate/crate-alerts/search?q=%22lrt.t1.dev+%3D+lrt.t2.devWHERE%22&type=issues) on the next day.

2. we recently fixed the query in https://github.com/crate/crate-benchmarks/commit/766046138ffb6bb788d3e03bfe4707267dc92b02 and now we have failures like
    
    `JobKilledException[Job killed. Received data for job=a0750cfc-5af0-79da-d020-6999047c3699 but there is no job   context present. This can happen due to bad network latency or if individual nodes are unresponsive due to high load] occurred using: {"stmt": "SELECT lrt.t1.dev, lrt.t2.name FROM lrt.t1 INNER JOIN lrt.t2 ON lrt.t1.dev = lrt.t2.dev WHERE lrt.t1.dev = CAST(random() * 127 AS BYTE) ORDER BY lrt.t2.name LIMIT 100"}`

2. we have some passed job entries like https://jenkins.crate.io/job/CrateDB/job/nightly/job/long_running/371/console
but it's not a "real pass" - they all have smth like `Run condition [Execute Shell] preventing perform for step [BuilderChain]
`

Let's try to lower concurrency?