### PR TITLE
lower concurrency for long-running query

### DIFF
--- a/long_running/queries.py
+++ b/long_running/queries.py
@@ -49,7 +49,7 @@ def get_queries():
                           'WHERE lrt.t1.dev = CAST(random() * 127 AS BYTE) '
                           'ORDER BY lrt.t2.name '
                           'LIMIT 100'),
-            'concurrency': 20,
+            'concurrency': 17,
             'duration': 1 * 60 * 60
         },
         {


### PR DESCRIPTION
follow up to https://github.com/crate/crate-benchmarks/commit/2979d0721d8e613ddbd47020377fc0de9f898c22 as JobKilledException error still pops up

Note, that this is not a regression as this query was never executed before due to syntax error.



