### PR TITLE
Include correlated_suubqueries spec in the default run

### DIFF
--- a/tracks/latest.toml
+++ b/tracks/latest.toml
@@ -22,6 +22,7 @@ queries = [
     "../specs/in_numeric.toml",
     "../specs/order_by_no_limit.toml",
     "../specs/select/simple_subquery.toml",
+    "../specs/select/correlated_subqueries.toml",
 ]
 full = [
     "../specs/insert_single.py",


### PR DESCRIPTION
Follow up of https://github.com/crate/crate-benchmarks/commit/93913f6.