### PR TITLE
Add 'if exists' to correlated subqueries teardown

### DIFF
--- a/specs/select/correlated_subqueries.toml
+++ b/specs/select/correlated_subqueries.toml
@@ -26,4 +26,4 @@ iterations = 1
 
 
 [teardown]
-statements = ["drop table uservisits"]
+statements = ["drop table if exists uservisits"]


### PR DESCRIPTION
Follow up to https://github.com/crate/crate-benchmarks/commit/93913f600338ba3a9a1a52776555ede66177f539

In order to align with https://github.com/crate/crate-benchmarks/commit/ddab6d42f6927a7bfa42a0b6312ecb54a6b3e053, which we did to address `RelationUnknown` errors

see https://jenkins.crate.io/job/CrateDB/job/nightly/job/crate-dev-cluster-bench/361/console

>  cr8 run-spec /var/lib/jenkins/workspace/CrateDB/nightly/crate-dev-cluster-bench/specs/select/correlated_subqueries.toml 'hosts' --action teardown
> SqlException: RelationUnknown[Relation 'uservisits' unknown] occurred using: {"stmt": "drop table uservisits"}

