### PR TITLE
lower concurrency for long-running query (third time) and slightly reduce duration

### DIFF
--- a/long_running/queries.py
+++ b/long_running/queries.py
@@ -49,7 +49,7 @@ def get_queries():
                           'WHERE lrt.t1.dev = CAST(random() * 127 AS BYTE) '
                           'ORDER BY lrt.t2.name '
                           'LIMIT 100'),
-            'concurrency': 17,
+            'concurrency': 10,
             'duration': 1 * 60 * 60
         },
         {


### PR DESCRIPTION
lower concurrency for long-running query (third time) and slightly reduce duration

follow up to https://github.com/crate/crate-benchmarks/commit/5c19435371d20c61b7ce1236d818c76e9ba88101 as JobKilledException error still pops up

 this is a heavy query (with unavoidable fullscan because of random in where) which was never executed before, so we have to keep tuning concurrency/duration util we get it working.

