### PR TITLE
Remove missing sys_shards.toml from latest track

### DIFF
--- a/tracks/latest.toml
+++ b/tracks/latest.toml
@@ -34,7 +34,6 @@ full = [
     "../specs/generated_columns.toml",
     "../specs/create_partitions.py",
     "../specs/information_schema.py",
-    "../specs/sys_shards.toml",
     "../specs/update_single.py",
     "../specs/update_bulk.py",
     "../specs/partitioned_bulk_insert.py",


### PR DESCRIPTION
The right path is `../specs/select/sys_shards` which is also in the list.
