### PR TITLE
Remove group by query from long_running

### DIFF
--- a/long_running/queries.py
+++ b/long_running/queries.py
@@ -52,12 +52,6 @@ def get_queries():
             'concurrency': 10,
             'duration': 1 * 60 * 60
         },
-        {
-            'statement': ('SELECT name, count(*) FROM lrt.t1 '
-                          'GROUP BY name ORDER BY 2 DESC LIMIT 500'),
-            'concurrency': 25,
-            'duration': 1 * 60 * 60
-        }
     )
 
 


### PR DESCRIPTION
The query gets stuck and causes the test to fail.
This removes it until we have a fix in place

Created https://github.com/crate/crate/issues/14111 to track it.