### PR TITLE
Reduce iterations in sys_select.toml

### DIFF
--- a/specs/select/sys_select.toml
+++ b/specs/select/sys_select.toml
@@ -7,52 +7,52 @@ statements = [
 
 [[queries]]
 statement = "select name from sys.cluster"
-iterations = 65000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select name from sys.cluster"
-iterations = 65000
+iterations = 15000
 concurrency = 15
 
 [[queries]]
 statement = "select * from sys.nodes"
-iterations = 10000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select * from sys.nodes"
-iterations = 30000
+iterations = 15000
 concurrency = 15
 
 [[queries]]
 statement = "select * from sys.allocations"
-iterations = 10000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select * from sys.jobs"
-iterations = 20000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select * from sys.operations"
-iterations = 20000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select * from sys.jobs_metrics"
-iterations = 10000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select * from sys.checks"
-iterations = 10000
+iterations = 5000
 concurrency = 1
 
 [[queries]]
 statement = "select * from sys.node_checks"
-iterations = 10000
+iterations = 5000
 concurrency = 1
 
 [[queries]]


### PR DESCRIPTION
The large number of iterations doesn't necessary lead to more stable
results.

E.g. comparing `latest-nightly` with `latest-nightly` leads to results
like:

    Q: select name from sys.cluster
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        0.053 ±    0.045 |      0.017 |      0.035 |      0.054 |      0.431 |
    |   V2    |        0.053 ±    0.049 |      0.018 |      0.036 |      0.055 |      0.405 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               +   1.64%                           +   4.02%

Or:

    Q: select * from sys.jobs
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        0.054 ±    0.040 |      0.026 |      0.059 |      0.065 |      1.189 |
    |   V2    |        0.044 ±    0.017 |      0.020 |      0.039 |      0.060 |      0.121 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  20.08%                           -  41.02%

The fluctuation seems to be in the range of 0-20%

With the reduced number of iterations, the fluctuation is about the
same but it takes less time:

    Q: select name from sys.cluster
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        0.179 ±    0.094 |      0.088 |      0.154 |      0.187 |      1.266 |
    |   V2    |        0.183 ±    0.098 |      0.080 |      0.158 |      0.191 |      1.372 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               +   2.62%                           +   2.70%

    Q: select * from sys.jobs
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        0.054 ±    0.020 |      0.021 |      0.052 |      0.067 |      0.227 |
    |   V2    |        0.053 ±    0.023 |      0.024 |      0.048 |      0.067 |      0.386 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   2.12%                           -   9.32%
