### PR TITLE
Reduce iterations in join-order-benchmark

### DIFF
--- a/join-order-benchmark/job.toml
+++ b/join-order-benchmark/job.toml
@@ -194,7 +194,7 @@ WHERE ci.note LIKE '%(voice)%'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "10b"
@@ -219,7 +219,7 @@ WHERE ci.note LIKE '%(producer)%'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "10c"
@@ -244,7 +244,7 @@ WHERE ci.note LIKE '%(producer)%'
   AND ct.id = mc.company_type_id;
 
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "11a"
@@ -278,7 +278,7 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mc.movie_id
   AND mk.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "11b"
@@ -313,7 +313,7 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mc.movie_id
   AND mk.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "11c"
@@ -349,7 +349,7 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mc.movie_id
   AND mk.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "11d"
@@ -383,7 +383,7 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mc.movie_id
   AND mk.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "12a"
@@ -417,7 +417,7 @@ WHERE cn.country_code = '[us]'
   AND mc.movie_id = mi_idx.movie_id
   AND mi.movie_id = mi_idx.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "12b"
@@ -451,7 +451,7 @@ WHERE cn.country_code ='[us]'
   AND mc.movie_id = mi_idx.movie_id
   AND mi.movie_id = mi_idx.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "12c"
@@ -487,7 +487,7 @@ WHERE cn.country_code = '[us]'
   AND mc.movie_id = mi_idx.movie_id
   AND mi.movie_id = mi_idx.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "13a"
@@ -520,7 +520,7 @@ WHERE cn.country_code ='[de]'
   AND mi.movie_id = mc.movie_id
   AND miidx.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "13b"
@@ -542,8 +542,7 @@ WHERE cn.country_code ='[us]'
   AND it2.info ='release dates'
   AND kt.kind ='movie'
   AND t.title != ''
-  AND (t.title LIKE '%Champion%'
-       OR t.title LIKE '%Loser%')
+  AND (t.title LIKE '%Champion%' OR t.title LIKE '%Loser%')
   AND mi.movie_id = t.id
   AND it2.id = mi.info_type_id
   AND kt.id = t.kind_id
@@ -556,7 +555,7 @@ WHERE cn.country_code ='[us]'
   AND mi.movie_id = mc.movie_id
   AND miidx.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "13c"
@@ -592,7 +591,7 @@ WHERE cn.country_code ='[us]'
   AND mi.movie_id = mc.movie_id
   AND miidx.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "13d"
@@ -625,7 +624,7 @@ WHERE cn.country_code ='[us]'
   AND mi.movie_id = mc.movie_id
   AND miidx.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "14a"
@@ -669,7 +668,7 @@ WHERE it1.info = 'countries'
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "14b"
@@ -714,7 +713,7 @@ WHERE it1.info = 'countries'
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "14c"
@@ -760,7 +759,7 @@ WHERE it1.info = 'countries'
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "15a"
@@ -797,7 +796,7 @@ WHERE cn.country_code = '[us]'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "15b"
@@ -835,7 +834,7 @@ WHERE cn.country_code = '[us]'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "15c"
@@ -872,7 +871,7 @@ WHERE cn.country_code = '[us]'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "15d"
@@ -906,7 +905,7 @@ WHERE cn.country_code = '[us]'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "16a"
@@ -936,7 +935,7 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "16b"
@@ -964,7 +963,7 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "16c"
@@ -993,7 +992,7 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "16d"
@@ -1023,7 +1022,7 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "17a"
@@ -1049,7 +1048,7 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "17b"
@@ -1074,7 +1073,7 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "17c"
@@ -1099,7 +1098,7 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "17d"
@@ -1123,7 +1122,7 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "17e"
@@ -1147,7 +1146,7 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "17f"
@@ -1171,7 +1170,7 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "18a"
@@ -1201,7 +1200,7 @@ WHERE ci.note IN ('(producer)',
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "18b"
@@ -1239,7 +1238,7 @@ WHERE ci.note IN ('(writer)',
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "18c"
@@ -1277,7 +1276,7 @@ WHERE ci.note IN ('(writer)',
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "19a"
@@ -1323,7 +1322,7 @@ WHERE ci.note IN ('(voice)',
   AND ci.person_id = an.person_id
   AND chn.id = ci.person_role_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "19b"
@@ -1367,7 +1366,7 @@ WHERE ci.note = '(voice)'
   AND ci.person_id = an.person_id
   AND chn.id = ci.person_role_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "19c"
@@ -1410,7 +1409,7 @@ WHERE ci.note IN ('(voice)',
   AND ci.person_id = an.person_id
   AND chn.id = ci.person_role_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "19d"
@@ -1449,7 +1448,7 @@ WHERE ci.note IN ('(voice)',
   AND ci.person_id = an.person_id
   AND chn.id = ci.person_role_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "1a"
@@ -1472,7 +1471,7 @@ WHERE ct.kind = 'production companies'
   AND mc.movie_id = mi_idx.movie_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 2
 
 [[queries]]
 name = "1b"
@@ -1494,7 +1493,7 @@ WHERE ct.kind = 'production companies'
   AND mc.movie_id = mi_idx.movie_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "1c"
@@ -1517,7 +1516,7 @@ WHERE ct.kind = 'production companies'
   AND mc.movie_id = mi_idx.movie_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "1d"
@@ -1539,7 +1538,7 @@ WHERE ct.kind = 'production companies'
   AND mc.movie_id = mi_idx.movie_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "20a"
@@ -1582,7 +1581,7 @@ WHERE cct1.kind = 'cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "20b"
@@ -1626,7 +1625,7 @@ WHERE cct1.kind = 'cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "20c"
@@ -1672,7 +1671,7 @@ WHERE cct1.kind = 'cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "21a"
@@ -1719,7 +1718,7 @@ WHERE cn.country_code !='[pl]'
   AND mk.movie_id = mi.movie_id
   AND mc.movie_id = mi.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "21b"
@@ -1760,7 +1759,7 @@ WHERE cn.country_code !='[pl]'
   AND mk.movie_id = mi.movie_id
   AND mc.movie_id = mi.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "21c"
@@ -1808,7 +1807,7 @@ WHERE cn.country_code !='[pl]'
   AND mk.movie_id = mi.movie_id
   AND mc.movie_id = mi.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "22a"
@@ -1860,7 +1859,7 @@ WHERE cn.country_code != '[us]'
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "22b"
@@ -1912,7 +1911,7 @@ WHERE cn.country_code != '[us]'
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "22c"
@@ -1970,7 +1969,7 @@ WHERE cn.country_code != '[us]'
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "22d"
@@ -2026,7 +2025,7 @@ WHERE cn.country_code != '[us]'
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "23a"
@@ -2069,7 +2068,7 @@ WHERE cct1.kind = 'complete+verified'
   AND ct.id = mc.company_type_id
   AND cct1.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "23b"
@@ -2114,7 +2113,7 @@ WHERE cct1.kind = 'complete+verified'
   AND ct.id = mc.company_type_id
   AND cct1.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "23c"
@@ -2160,7 +2159,7 @@ WHERE cct1.kind = 'complete+verified'
   AND ct.id = mc.company_type_id
   AND cct1.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "24a"
@@ -2214,7 +2213,7 @@ WHERE ci.note IN ('(voice)',
   AND chn.id = ci.person_role_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "24b"
@@ -2271,7 +2270,7 @@ WHERE ci.note IN ('(voice)',
   AND chn.id = ci.person_role_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "25a"
@@ -2317,7 +2316,7 @@ WHERE ci.note IN ('(writer)',
   AND it2.id = mi_idx.info_type_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "25b"
@@ -2365,7 +2364,7 @@ WHERE ci.note IN ('(writer)',
   AND it2.id = mi_idx.info_type_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "25c"
@@ -2418,7 +2417,7 @@ WHERE ci.note IN ('(writer)',
   AND it2.id = mi_idx.info_type_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "26a"
@@ -2475,7 +2474,7 @@ WHERE cct1.kind = 'cast'
   AND cct2.id = cc.status_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "26b"
@@ -2525,7 +2524,7 @@ WHERE cct1.kind = 'cast'
   AND cct2.id = cc.status_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "26c"
@@ -2580,7 +2579,7 @@ WHERE cct1.kind = 'cast'
   AND cct2.id = cc.status_id
   AND it2.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "27a"
@@ -2636,7 +2635,7 @@ WHERE cct1.kind IN ('cast',
   AND mc.movie_id = cc.movie_id
   AND mi.movie_id = cc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "27b"
@@ -2692,7 +2691,7 @@ WHERE cct1.kind IN ('cast',
   AND mc.movie_id = cc.movie_id
   AND mi.movie_id = cc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "27c"
@@ -2752,7 +2751,7 @@ WHERE cct1.kind = 'cast'
   AND mc.movie_id = cc.movie_id
   AND mi.movie_id = cc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "28a"
@@ -2822,7 +2821,7 @@ WHERE cct1.kind = 'crew'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "28b"
@@ -2886,7 +2885,7 @@ WHERE cct1.kind = 'crew'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "28c"
@@ -2956,7 +2955,7 @@ WHERE cct1.kind = 'cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "29a"
@@ -3027,7 +3026,7 @@ WHERE cct1.kind ='cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "29b"
@@ -3096,7 +3095,7 @@ WHERE cct1.kind ='cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "29c"
@@ -3166,7 +3165,7 @@ WHERE cct1.kind ='cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "2a"
@@ -3184,7 +3183,7 @@ WHERE cn.country_code ='[de]'
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "2b"
@@ -3202,7 +3201,7 @@ WHERE cn.country_code ='[nl]'
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "2c"
@@ -3220,7 +3219,7 @@ WHERE cn.country_code ='[sm]'
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "2d"
@@ -3238,7 +3237,7 @@ WHERE cn.country_code ='[us]'
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "30a"
@@ -3301,7 +3300,7 @@ WHERE cct1.kind IN ('cast',
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "30b"
@@ -3367,7 +3366,7 @@ WHERE cct1.kind IN ('cast',
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "30c"
@@ -3432,7 +3431,7 @@ WHERE cct1.kind = 'cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "31a"
@@ -3490,7 +3489,7 @@ WHERE ci.note IN ('(writer)',
   AND k.id = mk.keyword_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "31b"
@@ -3553,7 +3552,7 @@ WHERE ci.note IN ('(writer)',
   AND k.id = mk.keyword_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "31c"
@@ -3614,7 +3613,7 @@ WHERE ci.note IN ('(writer)',
   AND k.id = mk.keyword_id
   AND cn.id = mc.company_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "32a"
@@ -3635,7 +3634,7 @@ WHERE k.keyword ='10,000-mile-club'
   AND lt.id = ml.link_type_id
   AND mk.movie_id = t1.id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "32b"
@@ -3656,7 +3655,7 @@ WHERE k.keyword ='character-name-in-title'
   AND lt.id = ml.link_type_id
   AND mk.movie_id = t1.id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "33a"
@@ -3710,7 +3709,7 @@ WHERE cn1.country_code = '[us]'
   AND ml.linked_movie_id = mc2.movie_id
   AND mi_idx2.movie_id = mc2.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "33b"
@@ -3762,7 +3761,7 @@ WHERE cn1.country_code = '[nl]'
   AND ml.linked_movie_id = mc2.movie_id
   AND mi_idx2.movie_id = mc2.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "33c"
@@ -3818,7 +3817,7 @@ WHERE cn1.country_code != '[us]'
   AND ml.linked_movie_id = mc2.movie_id
   AND mi_idx2.movie_id = mc2.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "3a"
@@ -3842,7 +3841,7 @@ WHERE k.keyword LIKE '%sequel%'
   AND mk.movie_id = mi.movie_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "3b"
@@ -3859,7 +3858,7 @@ WHERE k.keyword LIKE '%sequel%'
   AND mk.movie_id = mi.movie_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "3c"
@@ -3885,7 +3884,7 @@ WHERE k.keyword LIKE '%sequel%'
   AND mk.movie_id = mi.movie_id
   AND k.id = mk.keyword_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "4a"
@@ -3906,7 +3905,7 @@ WHERE it.info ='rating'
   AND k.id = mk.keyword_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "4b"
@@ -3927,7 +3926,7 @@ WHERE it.info ='rating'
   AND k.id = mk.keyword_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "4c"
@@ -3948,7 +3947,7 @@ WHERE it.info ='rating'
   AND k.id = mk.keyword_id
   AND it.id = mi_idx.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "5a"
@@ -3976,7 +3975,7 @@ WHERE ct.kind = 'production companies'
   AND ct.id = mc.company_type_id
   AND it.id = mi.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "5b"
@@ -3999,7 +3998,7 @@ WHERE ct.kind = 'production companies'
   AND ct.id = mc.company_type_id
   AND it.id = mi.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "5c"
@@ -4029,7 +4028,7 @@ WHERE ct.kind = 'production companies'
   AND ct.id = mc.company_type_id
   AND it.id = mi.info_type_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "6a"
@@ -4050,7 +4049,7 @@ WHERE k.keyword = 'marvel-cinematic-universe'
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "6b"
@@ -4078,7 +4077,7 @@ WHERE k.keyword IN ('superhero',
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "6c"
@@ -4099,7 +4098,7 @@ WHERE k.keyword = 'marvel-cinematic-universe'
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "6d"
@@ -4127,7 +4126,7 @@ WHERE k.keyword IN ('superhero',
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "6e"
@@ -4148,7 +4147,7 @@ WHERE k.keyword = 'marvel-cinematic-universe'
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "6f"
@@ -4175,7 +4174,7 @@ WHERE k.keyword IN ('superhero',
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "7a"
@@ -4210,7 +4209,7 @@ WHERE an.name LIKE '%a%'
   AND an.person_id = ci.person_id
   AND ci.movie_id = ml.linked_movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "7b"
@@ -4243,7 +4242,7 @@ WHERE an.name LIKE '%a%'
   AND an.person_id = ci.person_id
   AND ci.movie_id = ml.linked_movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "7c"
@@ -4283,7 +4282,7 @@ WHERE an.name IS NOT NULL
   AND an.person_id = ci.person_id
   AND ci.movie_id = ml.linked_movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "8a"
@@ -4312,7 +4311,7 @@ WHERE ci.note ='(voice: English version)'
   AND an1.person_id = ci.person_id
   AND ci.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "8b"
@@ -4346,7 +4345,7 @@ WHERE ci.note ='(voice: English version)'
   AND an.person_id = ci.person_id
   AND ci.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "8c"
@@ -4370,7 +4369,7 @@ WHERE cn.country_code ='[us]'
   AND a1.person_id = ci.person_id
   AND ci.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "8d"
@@ -4394,7 +4393,7 @@ WHERE cn.country_code ='[us]'
   AND an1.person_id = ci.person_id
   AND ci.movie_id = mc.movie_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "9a"
@@ -4431,7 +4430,7 @@ WHERE ci.note IN ('(voice)',
   AND an.person_id = n.id
   AND an.person_id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "9b"
@@ -4466,7 +4465,7 @@ WHERE ci.note = '(voice)'
   AND an.person_id = n.id
   AND an.person_id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "9c"
@@ -4500,7 +4499,7 @@ WHERE ci.note IN ('(voice)',
   AND an.person_id = n.id
   AND an.person_id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 [[queries]]
 name = "9d"
@@ -4533,7 +4532,7 @@ WHERE ci.note IN ('(voice)',
   AND an.person_id = n.id
   AND an.person_id = ci.person_id;
 """
-iterations = 10
+iterations = 1
 
 
 [teardown]


### PR DESCRIPTION
Most of these queries are currently really slow.
Reduce iterations until we've a couple of results and a better overview
of which are fast enough to turn the number of iterations up
