### PR TITLE
Revert "Pin argh dependency to 0.29.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ agate-excel==0.2.5
 agate-sql==0.5.9
 aiohttp==3.8.4
 aiosignal==1.3.1
-argh==0.29.4
+argh==0.28.1
 async-timeout==4.0.2
 asyncpg==0.28.0
 attrs==23.1.0
@@ -12,7 +12,7 @@ Babel==2.12.1
 charset-normalizer==3.2.0
 colorama==0.4.6
 contourpy==1.1.0
-cr8==0.23.0
+cr8==0.25.0
 crash==0.30.0
 crate==0.32.0
 csvkit==1.1.1


### PR DESCRIPTION
``cr8 0.25.0`` adds compatibility for ``argh>=0.30.1``

This reverts commit cb82b8f11ecc5dffe724d29b4e396f4ff4a1707b.
