### PR TITLE
Reduce fluctuation of correlated-subquery

### DIFF
--- a/specs/select/correlated_subqueries.toml
+++ b/specs/select/correlated_subqueries.toml
@@ -22,7 +22,7 @@ name = "correlated subquery with filter on parent relation"
 statement = '''SELECT COUNT(*) FROM uservisits u WHERE "lCode" LIKE '%-EN' AND EXISTS (SELECT 1 FROM uservisits WHERE "cCode" = u."cCode")'''
 warmup = 1
 concurrency = 1
-iterations = 1
+iterations = 3
 
 
 [teardown]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

As can be seen from 

https://tools.cr8.net/grafana/d/-8PNA2vnz/cratedb-dev-cluster-benchmarks?orgId=1&var-spec_file=correlated_subqueries.toml&var-statement=SELECT%20COUNT%28%2A%29%20FROM%20uservisits%20u%20WHERE%20%22lCode%22%20LIKE%20%27%25-EN%27%20AND%20EXISTS%20%28SELECT%201%20FROM%20uservisits%20WHERE%20%22cCode%22%20%3D%20u.%22cCode%22%29&var-concurrency=1&from=now-6M&to=now

the benchmark results on dev cluster fluctuates as much as 1 minute when it typically runs for 3-4 minutes.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
