### PR TITLE
Add spec file for UDF

### DIFF
--- a/specs/udf.toml
+++ b/specs/udf.toml
@@ -1,0 +1,27 @@
+[setup]
+statements = [
+  """
+  create or replace function jsadd(x long, y long)
+  returns long
+  language javascript as $$
+    function jsadd(x, y) {
+      return x + y;
+    }
+  $$
+  """
+]
+
+
+[[queries]]
+name = "jsadd"
+statement = "select jsadd(x, x) from generate_series(1, 50) as t (x)"
+iterations = 50
+
+[[queries]]
+name = "normal-add"
+statement = "select x + x from generate_series(1, 50) as t (x)"
+iterations = 50
+
+
+[teardown]
+statements = ["drop function if exists jsadd(x long, y long)"]


### PR DESCRIPTION
Just used this to test if it is feasible to remove the `compile` variant of the udf-scalar implementation. (It's not).

But might as well add the file.