### PR TITLE
Revert "Add group by distribution to the full run"

### DIFF
--- a/tracks/latest.toml
+++ b/tracks/latest.toml
@@ -61,6 +61,4 @@ full = [
     "../specs/union.toml",
     "../specs/ignore3vl.toml",
     "../specs/lookup_join.toml",
-    "../specs/group_by_distribution_long.toml",
-    "../specs/group_by_distribution_string.toml",
 ]


### PR DESCRIPTION
It's not part of the latest.toml

This reverts commit c3817c1653724dae1ca37a82c49aa6ae15993436.

