### PR TITLE
Make compare_run_disk_usage working again

### DIFF
--- a/compare_run_disk_usage.py
+++ b/compare_run_disk_usage.py
@@ -11,7 +11,7 @@ from cr8.run_crate import get_crate, CrateNode
 from cr8.run_spec import do_run_spec
 from cr8.log import Logger
 from crate.client import connect
-from crate.crash.tabulate import tabulate
+from tabulate import tabulate
 
 from util import dict_from_kw_args, perc_diff, human_readable_byte_size
 from lucene_disk_usage import gather_sizes

--- a/requirements-raw.txt
+++ b/requirements-raw.txt
@@ -6,3 +6,4 @@ numpy
 crash
 plotext
 csvkit
+tabulate


### PR DESCRIPTION
`compare_run_disk_usage.py` was broken because the tabulate import from crash was broken. This declares the dependency explicitly and makes the script work again.

Related to https://github.com/crate/crash/commit/2a0ea945ddc8519cc066550bd66527ce284e1757

## Summary of the changes / Why this is an improvement


## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
