### PR TITLE
Fix size calculation for numerical data

### DIFF
--- a/compare_run_disk_usage.py
+++ b/compare_run_disk_usage.py
@@ -79,7 +79,9 @@ def run_comparison(version1,
         ('Term Vector Index', 'tvx'),
         ('Term Vector Data', 'tvd'),
         ('Live Documents', 'liv'),
-        ('Point values', 'dii')
+        ('Point values (kdd)', 'kdd'),
+        ('Point values (kdi)', 'kdi'),
+        ('Point values (kdm)', 'kdm')
     ]
 
     def mk_row(key):
@@ -90,6 +92,14 @@ def run_comparison(version1,
         v2_size, v2_unit = human_readable_byte_size(val2)
         return (description, v1_size, v1_unit, v2_size, v2_unit, perc_diff(val1, val2))
     rows = [mk_row(key) for key in keys]
+
+    v1_sum = sum(v1.values())
+    v2_sum = sum(v2.values())
+    v1_sum_size, v1_sum_unit = human_readable_byte_size(v1_sum)
+    v2_sum_size, v2_sum_unit = human_readable_byte_size(v2_sum)
+    sum_diff = ('Total', v1_sum_size, v1_sum_unit, v2_sum_size, v2_sum_unit, perc_diff(v1_sum, v2_sum))
+    rows.append(sum_diff)
+
     print(tabulate(rows, headers=headers, floatfmt=".2f"))
 
 

--- a/lucene_disk_usage.py
+++ b/lucene_disk_usage.py
@@ -26,8 +26,9 @@ KNOWN_EXTENSIONS = {
     'tvx',
     'tvd',
     'liv',
-    'dii',
-    'dim',
+    'kdd',
+    'kdi',
+    'kdm',    
 }
 
 
@@ -55,6 +56,7 @@ def main(argv=None):
     parser.add_argument('--outfile', type=argparse.FileType('w'), default=sys.stdout)
     args = parser.parse_args(argv)
     sizes = gather_sizes(args.path)
+    sizes['total'] = sum(sizes.values())
 
     # https://lucene.apache.org/core/8_9_0/core/org/apache/lucene/codecs/lucene87/package-summary.html#package.description
     if args.format == 'json':
@@ -77,8 +79,10 @@ Per-Document Values: {format_byte_size(sizes['dvd'])}
 Term Vector Index:   {format_byte_size(sizes['tvx'])}
 Term Vector Data:    {format_byte_size(sizes['tvd'])}
 Live Documents:      {format_byte_size(sizes['liv'])}
-Point values:        {format_byte_size(sizes['dii'])}
-                     {format_byte_size(sizes['dim'])}
+Point values:        {format_byte_size(sizes['kdd'])}
+                     {format_byte_size(sizes['kdi'])}
+                     {format_byte_size(sizes['kdm'])} 
+Total:               {format_byte_size(sizes['total'])} 
 ''')
 
 


### PR DESCRIPTION
This fixes the size calculation for numerical data in lucene indices and adds a total row to the results. The new output for `compare_run_disk_usage` looks like this:

```
Description             Version 1  Unit      Version 2  Unit      Diff
--------------------  -----------  ------  -----------  ------  ------
Segment Info                 8.99  KB             8.99  KB        0.00
Fields                       7.44  KB             7.35  KB        1.32
Field Index                 39.21  KB            13.24  KB       99.05
Field Data                 409.80  MB            89.69  MB      128.18
Term Dictionary            155.97  MB           155.97  MB        0.00
Term Index                   1.27  MB             1.27  MB        0.01
Frequencies                 48.64  MB            48.58  MB        0.13
Positions                    8.56  MB             8.55  MB        0.01
Payloads                     0.00  Bytes          0.00  Bytes     0.00
Norms (nvd)                  3.68  MB             3.68  MB        0.00
Norms (nvm)                556.00  Bytes        556.00  Bytes     0.00
Per-Doc Values (dvd)       170.19  MB           170.19  MB        0.00
Per-Doc Values (dvm)         9.58  KB             9.58  KB        0.00
Term Vector Index            0.00  Bytes          0.00  Bytes     0.00
Term Vector Data             0.00  Bytes          0.00  Bytes     0.00
Live Documents               0.00  Bytes          0.00  Bytes     0.00
Point values (kdd)          44.30  MB            40.98  MB        7.79
Point values (kdi)         158.97  KB           158.78  KB        0.12
Point values (kdm)           1.26  KB             1.26  KB        0.00
Total                      842.62  MB           519.11  MB       47.52
```

and for the `lucene_disk_usage`:

```
{
    "tim": 125269018,
    "tip": 11729181,
    "doc": 3883387,
    "fdt": 1026333635,
    "si": 6612,
    "fdx": 153014,
    "fnm": 9499,
    "dvd": 1086656460,
    "dvm": 16592,
    "kdm": 4768,
    "kdd": 461031933,
    "kdi": 2373192,
    "total": 2717467291
}
```

and 

```
Segment Info:            6.46 KB
Fields:                  9.28 KB
Field Index:           149.43 KB
Field Data:            978.79 MB
Term Dictionary:       119.47 MB
Term Index:             11.19 MB
Frequencies:             3.70 MB
Positions:               0.00 Bytes
Payloads:                0.00 Bytes
Norms:                   0.00 Bytes
                         0.00 Bytes
Per-Document Values:     1.01 GB
                        16.20 KB
Term Vector Index:       0.00 Bytes
Term Vector Data:        0.00 Bytes
Live Documents:          0.00 Bytes
Point values:          439.67 MB
                         2.26 MB
                         4.66 KB 
Total:                   2.53 GB 
```

## Summary of the changes / Why this is an improvement


## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
