### PR TITLE
Use aggregate.toml as a base for fixtures.

### DIFF
--- a/tracks/latest.toml
+++ b/tracks/latest.toml
@@ -8,7 +8,7 @@ configurations = [
 
 [specs]
 fixtures = [
-    "../specs/group_by.toml"
+    "../specs/aggregate.toml"
 ]
 queries = [
     "../specs/group_by.toml",


### PR DESCRIPTION
We use track file to run benchmarks and setup from the spec specified in fixtures is called once

standalone run-spec works but to make run-track work we need to use fixture that creates all tables required in other benchmarks

Fixes https://github.com/crate/crate-alerts/issues/708