### PR TITLE
Reduce concurrency to prevent CBE

### DIFF
--- a/specs/select/hash_joins.toml
+++ b/specs/select/hash_joins.toml
@@ -36,7 +36,7 @@ concurrency = 5
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000'
 iterations = 20
 min_version = '3.0.0'
-concurrency = 17
+concurrency = 14
 
 [[queries]]
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000000'


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
crate-public-benchmark started to fail and is blocking the nightly releases, see https://github.com/crate/crate-alerts/issues/739 for details. The Jenkins results can be interpreted as some sort of a regression but it could not reproduced locally(could not reproduce the good state before it started to fail, in addition there were no signs of increase in memory consumptions of the hash join operations).

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #???
