### PR TITLE
Remove hash join case with concurrency=17

### DIFF
--- a/specs/select/hash_joins.toml
+++ b/specs/select/hash_joins.toml
@@ -15,12 +15,6 @@ min_version = '3.0.0'
 concurrency = 5
 
 [[queries]]
-statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000'
-iterations = 20
-min_version = '3.0.0'
-concurrency = 17
-
-[[queries]]
 statement = 'select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000'
 iterations = 20
 min_version = '3.0.0'


### PR DESCRIPTION
The scenario currently runs often into circuit breaker exceptions.
This removes it until we have a solution for that in CrateDB to avoid
notiification noise and interferring with other benchmarks.

(Possible solution being spilling to disk:
https://github.com/crate/crate/issues/17431 - added a note to it to undo this PR)
