### PR TITLE
Revert "Remove group by query from long_running"

### DIFF
--- a/long_running/queries.py
+++ b/long_running/queries.py
@@ -52,6 +52,12 @@ def get_queries():
             'concurrency': 10,
             'duration': 1 * 60 * 60
         },
+        {
+            'statement': ('SELECT name, count(*) FROM lrt.t1 '
+                          'GROUP BY name ORDER BY 2 DESC LIMIT 500'),
+            'concurrency': 25,
+            'duration': 1 * 60 * 60
+        }
     )
 
 


### PR DESCRIPTION
This reverts commit 571e415d6a53fe13dde93313680fdf681669fa08.

Fix (https://github.com/crate/crate/pull/14114) was merged long time ago, we can get this spec back.

Motivation: encountered 2 support issues where streaming of the `TransportDistributedResultAction` leads to OOM

In case we get back cbeCanTrip to avoid OOM-s (and come up with an alternative solution), we need a spec which can catch regressions


See https://github.com/crate/support/issues/686#issuecomment-3083056405 and https://github.com/crate/support/issues/674#issuecomment-3150275854





