### PR TITLE
Extend group by benchmark with query including filters

### DIFF
--- a/specs/group_by.toml
+++ b/specs/group_by.toml
@@ -34,6 +34,12 @@ concurrency = 15
 iterations = 100
 
 [[queries]]
+name = "group by 1 string key with query"
+statement = '''select "cCode", avg(duration), avg("adRevenue") from uservisits where "cCode" in ('AUT', 'DEU') group by "cCode"'''
+concurrency = 1
+iterations = 100
+
+[[queries]]
 statement = '''select min("adRevenue") from uservisits group by "cCode"'''
 concurrency = 15
 iterations = 100


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/19448
