### PR TITLE
Add benchmark for term frequency group by optimization

### DIFF
--- a/specs/group_by.toml
+++ b/specs/group_by.toml
@@ -34,6 +34,12 @@ concurrency = 15
 iterations = 100
 
 [[queries]]
+name = "count star and group by a single not-null string key"
+statement = '''select "lCode", count(*) from uservisits group by "lCode"'''
+concurrency = 15
+iterations = 100
+
+[[queries]]
 name = "group by 1 string key with query"
 statement = '''select "cCode", avg(duration), avg("adRevenue") from uservisits where "cCode" in ('AUT', 'DEU') group by "cCode"'''
 concurrency = 1

--- a/specs/sql/uservisits.sql
+++ b/specs/sql/uservisits.sql
@@ -4,8 +4,8 @@ CREATE TABLE uservisits (
    "visitDate" TIMESTAMP,
    "adRevenue" FLOAT,
    "UserAgent" STRING INDEX USING FULLTEXT,
-   "cCode" STRING,
-   "lCode" STRING,
+   "cCode" varchar(3),
+   "lCode" STRING NOT NULL,
    "searchWord" STRING,
    "duration" INTEGER,
    INDEX uagent_plain USING PLAIN("UserAgent")


### PR DESCRIPTION
Relates to:

- https://github.com/crate/crate/pull/19450
- https://github.com/crate/crate/pull/19404

```
## Running Query:
    Name: count star and group by a single string key
    Statement:
        select "cCode", count(*) from uservisits group by "cCode"
    Concurrency: 15
    Iterations: 100
Runtime (in ms):
    mean:    52.983 ± 4.472
    min/max: 27.969 → 129.779
Percentile:
    50:   46.941 ± 22.814 (stdev)
    95:   115.148
    99.9: 129.779

## Running Query:
    Name: count star and group by a single not-null string key
    Statement:
        select "lCode", count(*) from uservisits group by "lCode"
    Concurrency: 15
    Iterations: 100
Runtime (in ms):
    mean:    4.314 ± 0.735
    min/max: 0.497 → 16.289
Percentile:
    50:   2.902 ± 3.748 (stdev)
    95:   12.643
    99.9: 16.289
```
